### PR TITLE
Update Pegdown to its latest version

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-markdown/pom.xml
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-markdown/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.pegdown</groupId>
       <artifactId>pegdown</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.rendering</groupId>


### PR DESCRIPTION
Pegdown is now 1.2.0.
Update from 1.1.0.
