### PR TITLE
XRENDERING-324: ConfluenceXHTMLParser does not repair CDATA containing ]]

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-confluencexhtml/src/main/java/org/xwiki/rendering/internal/parser/confluencexhtml/ConfluenceXHTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-confluencexhtml/src/main/java/org/xwiki/rendering/internal/parser/confluencexhtml/ConfluenceXHTMLParser.java
@@ -96,6 +96,7 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         Map<String, TagHandler> handlers = new HashMap<String, TagHandler>();
 
         handlers.put("ac:macro", new MacroTagHandler());
+        handlers.put("ac:structured-macro", new MacroTagHandler());
         handlers.put("ac:parameter", new ParameterTagHandler());
         handlers.put("ac:plain-text-body", new PlainTextBodyTagHandler());
 
@@ -126,7 +127,7 @@ public class ConfluenceXHTMLParser extends AbstractWikiModelParser
         }
 
         // Confluence generate invalid CDATA (nice touch...)
-        content = content.replaceAll("(<!\\[CDATA\\[[^\\]]*\\]\\]) (>)", "$1$2");
+        content = content.replaceAll("]] ", "]]");
 
         // Add <void> element around the content to make sure to have valid xml
         content = "<void>" + content + "</void>";

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-confluencexhtml/src/test/resources/confluence+xhtml10/specific/misc/XRENDERING-324.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-confluencexhtml/src/test/resources/confluence+xhtml10/specific/misc/XRENDERING-324.test
@@ -1,0 +1,26 @@
+.#-----------------------------------------------------
+.input|confluence+xhtml/1.0
+.# repairing the CDATA sections by removing the space after every ]]
+.# the space in the export format is really added after every ]], no matter if CDATA or not 
+.#-----------------------------------------------------
+<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[<![CDATA[nested]] ]] ><![CDATA[>]] ></ac:plain-text-body></ac:structured-macro>
+<p>[[plain]] text</p>
+.#-----------------------------------------------------
+.###expect|event/1.0
+.#macro<![CDATA[nested]]>
+.#
+.#[[plain]]text
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [code] [] [&#x3c;![CDATA[nested]]&#x3e;]
+beginParagraph
+onSpecialSymbol [[]
+onSpecialSymbol [[]
+onWord [plain]
+onSpecialSymbol []]
+onSpecialSymbol []]
+onWord [text]
+endParagraph
+endDocument


### PR DESCRIPTION
the export adds a space after every ]], so all we need to do is to scrap it there, unconditionally
