### PR TITLE
Component deprecated

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/EmptyLinesBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/EmptyLinesBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("emptylines")
+@Component
+@Named("emptylines")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class EmptyLinesBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/FormatBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/FormatBlockParser.java
@@ -22,13 +22,16 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.xdomxml10.internal.renderer.parameter.FormatConverter;
 
-@Component("format")
+@Component
+@Named("format")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class FormatBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/HeaderBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/HeaderBlockParser.java
@@ -22,13 +22,16 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.xdomxml10.internal.renderer.parameter.HeaderLevelConverter;
 
-@Component("header")
+@Component
+@Named("header")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class HeaderBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/IdBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/IdBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("id")
+@Component
+@Named("id")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class IdBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ImageBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ImageBlockParser.java
@@ -22,6 +22,8 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
@@ -29,7 +31,8 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.xdomxml10.internal.parser.parameter.ResourceReferenceParser;
 
-@Component("image")
+@Component
+@Named("image")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class ImageBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/LinkBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/LinkBlockParser.java
@@ -22,6 +22,8 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
@@ -29,7 +31,8 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.xdomxml10.internal.parser.parameter.ResourceReferenceParser;
 
-@Component("link")
+@Component
+@Named("link")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class LinkBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ListBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ListBlockParser.java
@@ -22,13 +22,16 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.xdomxml10.internal.renderer.parameter.ListTypeConverter;
 
-@Component("list")
+@Component
+@Named("list")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class ListBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MacroBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MacroBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("macro")
+@Component
+@Named("macro")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class MacroBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MacroMarkerBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MacroMarkerBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("macromarker")
+@Component
+@Named("macromarker")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class MacroMarkerBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/RawTextBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/RawTextBlockParser.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
@@ -31,7 +32,8 @@ import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.syntax.SyntaxFactory;
 
-@Component("rawtext")
+@Component
+@Named("rawtext")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class RawTextBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/SpecialSymbolBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/SpecialSymbolBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("specialsymbol")
+@Component
+@Named("specialsymbol")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class SpecialSymbolBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/VerbatimBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/VerbatimBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("verbatim")
+@Component
+@Named("verbatim")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class VerbatimBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/WordBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/WordBlockParser.java
@@ -22,12 +22,15 @@ package org.xwiki.rendering.xdomxml10.internal.parser;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.inject.Named;
+
 import org.xml.sax.SAXException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 
-@Component("word")
+@Component
+@Named("word")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class WordBlockParser extends DefaultBlockParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/XDOMXMLContentHandlerStreamParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/XDOMXMLContentHandlerStreamParser.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.xdomxml10.internal.parser;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.dom4j.io.SAXContentHandler;
 import org.xml.sax.Attributes;
@@ -35,7 +36,8 @@ import org.xwiki.rendering.parser.xml.ContentHandlerStreamParser;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.xdomxml10.internal.XDOMXMLConstants;
 
-@Component("xdom+xml/1.0")
+@Component
+@Named("xdom+xml/1.0")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class XDOMXMLContentHandlerStreamParser extends DefaultHandler implements ContentHandlerStreamParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/XDOMXMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/XDOMXMLParser.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rendering.xdomxml10.internal.parser;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -30,7 +31,8 @@ import org.xwiki.rendering.xml.internal.parser.AbstractParser;
  * 
  * @version $Id$
  */
-@Component("xdom+xml/1.0")
+@Component
+@Named("xdom+xml/1.0")
 @Singleton
 public class XDOMXMLParser extends AbstractParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/renderer/XDOMXMLContentHandlerStreamRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/renderer/XDOMXMLContentHandlerStreamRenderer.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rendering.xdomxml10.internal.renderer;
 
+import javax.inject.Named;
+
 import org.xml.sax.ContentHandler;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
@@ -29,7 +31,8 @@ import org.xwiki.rendering.listener.chaining.ListenerChain;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.xml.internal.renderer.AbstractChainingContentHandlerStreamRenderer;
 
-@Component("xdom+xml/1.0")
+@Component
+@Named("xdom+xml/1.0")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class XDOMXMLContentHandlerStreamRenderer extends AbstractChainingContentHandlerStreamRenderer implements
     Initializable

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/renderer/XDOMXMLRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/renderer/XDOMXMLRenderer.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rendering.xdomxml10.internal.renderer;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -28,7 +29,8 @@ import org.xwiki.rendering.xml.internal.renderer.AbstractRenderer;
 /**
  * @version $Id$
  */
-@Component("xdom+xml/1.0")
+@Component
+@Named("xdom+xml/1.0")
 @Singleton
 public class XDOMXMLRenderer extends AbstractRenderer
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/parser/XDOMXMLContentHandlerStreamParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/parser/XDOMXMLContentHandlerStreamParser.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.xdomxmlcurrent.internal.parser;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -39,7 +40,8 @@ import org.xwiki.rendering.syntax.Syntax;
  * @version $Id$
  * @since 3.3M1
  */
-@Component("xdom+xml/current")
+@Component
+@Named("xdom+xml/current")
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class XDOMXMLContentHandlerStreamParser implements ContentHandlerStreamParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/parser/XDOMXMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/parser/XDOMXMLParser.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rendering.xdomxmlcurrent.internal.parser;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -31,7 +32,8 @@ import org.xwiki.rendering.xml.internal.parser.AbstractParser;
  * @version $Id$
  * @since 3.3M1
  */
-@Component("xdom+xml/current")
+@Component
+@Named("xdom+xml/current")
 @Singleton
 public class XDOMXMLParser extends AbstractParser
 {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/renderer/XDOMXMLRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxmlcurrent/src/main/java/org/xwiki/rendering/xdomxmlcurrent/internal/renderer/XDOMXMLRenderer.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.xdomxmlcurrent.internal.renderer;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -34,7 +35,8 @@ import org.xwiki.rendering.xml.internal.renderer.AbstractRenderer;
  * @version $Id$
  * @since 3.3M1
  */
-@Component("xdom+xml/current")
+@Component
+@Named("xdom+xml/current")
 @Singleton
 public class XDOMXMLRenderer extends AbstractRenderer
 {


### PR DESCRIPTION
There was a few deprecated used of `@Component("something")` instead of 

```
@Component
@Named("something")
```