### PR TITLE
[codestyle] changed locale to english

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/listener/descriptor/DefaultListenerDescriptorManager.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/listener/descriptor/DefaultListenerDescriptorManager.java
@@ -21,6 +21,7 @@ package org.xwiki.rendering.internal.listener.descriptor;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -115,7 +116,7 @@ public class DefaultListenerDescriptorManager implements ListenerDescriptorManag
      */
     private void addElement(String elementName, ListenerDescriptor descriptor, Method method)
     {
-        String lowerElementName = elementName.toLowerCase();
+        String lowerElementName = elementName.toLowerCase(Locale.ENGLISH);
 
         ListenerElement element = descriptor.getElements().get(lowerElementName);
 

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/listener/descriptor/DefaultListenerDescriptorManager.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/listener/descriptor/DefaultListenerDescriptorManager.java
@@ -116,7 +116,7 @@ public class DefaultListenerDescriptorManager implements ListenerDescriptorManag
      */
     private void addElement(String elementName, ListenerDescriptor descriptor, Method method)
     {
-        String lowerElementName = elementName.toLowerCase(Locale.ENGLISH);
+        String lowerElementName = elementName.toLowerCase(Locale.ROOT);
 
         ListenerElement element = descriptor.getElements().get(lowerElementName);
 


### PR DESCRIPTION
toUpperCase() and toLowerCase() can cause problems with other languages such as Turkish. This is because toLowerCase() actually calls toLowerCase(Locale.default) and the default locale varies based on location.