### PR TITLE
[codestyle] Remove duplicate block of code

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/MacroBlock.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/MacroBlock.java
@@ -140,17 +140,4 @@ public class MacroBlock extends AbstractBlock
 
         return false;
     }
-
-    @Override
-    public int hashCode()
-    {
-        HashCodeBuilder builder = new HashCodeBuilder();
-
-        builder.appendSuper(super.hashCode());
-        builder.append(getContent());
-        builder.append(getId());
-        builder.append(isInline());
-
-        return builder.toHashCode();
-    }
 }


### PR DESCRIPTION
Removed hashCode() due it being a duplicate method already existing in MacroMarkerBlock.