### PR TITLE
[codestyle] Position literals first in String comparisons for EqualsIgnoreCase

### DIFF
--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
@@ -117,7 +117,7 @@ public class TestDataParser
                 saveBuffer(buffer, data.inputs, keyName);
             } else if (action.equalsIgnoreCase("expect")) {
                 saveBuffer(buffer, data.expectations, keyName);
-            } else if (action.equalsIgnoreCase("inputexpect")) {
+            } else if ("inputexpect".equalsIgnoreCase(action)) {
                 saveBuffer(buffer, data.inputs, keyName);
                 saveBuffer(buffer, data.expectations, keyName);
             }


### PR DESCRIPTION
Update TestDataParser.java by Positioning literals first in String comparisons for EqualsIgnoreCase.