### PR TITLE
[codestyle] Change comparison to use equals method

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroManager.java
@@ -106,7 +106,7 @@ public class DefaultMacroManager implements MacroManager
                     + "For example \"html/xwiki/2.0\". This macro will not be available in the system.");
                 continue;
             }
-            if (syntax == null || macroId.getSyntax() == null || syntax == macroId.getSyntax()) {
+            if (syntax == null || macroId.getSyntax() == null || syntax.equals(macroId.getSyntax())) {
                 result.add(macroId);
             }
         }


### PR DESCRIPTION
Changed comparison to use the `.equals()` method. This resolves the issue [here](http://sonar.xwiki.org/coding_rules#rule_key=squid%3AS1698)