### PR TITLE
Avoid declaring a variable if it is unreferenced before a possible exit point

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/XDOMBuilder.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/XDOMBuilder.java
@@ -52,13 +52,14 @@ public class XDOMBuilder
      */
     public XDOM getXDOM()
     {
-        List<Block> blocks = endBlockList();
-
+        
         if (!this.stack.isEmpty()) {
             throw new IllegalStateException("Unbalanced begin/end Block events, missing " + this.stack.size()
                 + " calls to endBlockList().");
         }
-
+        
+        List<Block> blocks = endBlockList();
+        
         // support even events without begin/endDocument for partial content
         if (!blocks.isEmpty() && blocks.get(0) instanceof XDOM) {
             return (XDOM) blocks.get(0);

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/XDOMBuilder.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/XDOMBuilder.java
@@ -53,7 +53,7 @@ public class XDOMBuilder
     public XDOM getXDOM()
     {
         
-        if (!this.stack.isEmpty()) {
+        if (!this.stack.size()==1) {
             throw new IllegalStateException("Unbalanced begin/end Block events, missing " + this.stack.size()
                 + " calls to endBlockList().");
         }


### PR DESCRIPTION
I moved the declaration of the variable so it would not be premature.