### PR TITLE
[codestyle] removed useless parentheses and reordered .equals

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiImageTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiImageTagHandler.java
@@ -91,9 +91,7 @@ public class XWikiImageTagHandler extends ImgTagHandler implements XWikiWikiMode
     protected WikiParameters removeMeaningfulParameters(WikiParameters parameters)
     {
         WikiParameter classParam = parameters.getParameter("class");
-        boolean isFreeStanding =
-            ((classParam != null) && classParam.getValue().equalsIgnoreCase("wikimodel-freestanding"));
-
+        boolean isFreeStanding = classParam != null && "wikimodel-freestanding".equalsIgnoreCase(classParam.getValue());
         if (isFreeStanding) {
             return removeFreestanding(parameters).remove("alt").remove("src");
         } else {


### PR DESCRIPTION
getValue() might be null even if classParam isn't
http://sonar.xwiki.org/issues/search#issues=c8e016a7-c1f8-4f4a-9e94-8f1bc018f96d
http://sonar.xwiki.org/issues/search#issues=0c51b787-ec53-4935-b64f-ec4fda5c5a43
http://sonar.xwiki.org/issues/search#issues=f0613c7f-5b8c-4868-9ea6-4093a46224a0