### PR TITLE
[codestyle] Avoid using redundant field initializer for 'foundWord'

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/WikiModelParserUtils.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/WikiModelParserUtils.java
@@ -51,9 +51,9 @@ public class WikiModelParserUtils extends ParserUtils
         if (prefix) {
             WrappingListener inlineFilterListener = new InlineFilterListener()
             {
-                private boolean foundWord = false;
+                private boolean foundWord;
 
-                private boolean foundSpace = false;
+                private boolean foundSpace;
 
                 @Override
                 public void onWord(String word)


### PR DESCRIPTION
1.  http://sonar.xwiki.org/issues/search#issues=3c1b185e-bf69-40e1-b961-51d0fb5ac04e
2.  http://sonar.xwiki.org/issues/search#issues=436a2f3b-043e-4798-85a7-54d6456664ce