### PR TITLE
[codestyle] Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". 

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-doxia/src/main/java/org/xwiki/rendering/internal/parser/doxia/XWikiGeneratorSink.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-doxia/src/main/java/org/xwiki/rendering/internal/parser/doxia/XWikiGeneratorSink.java
@@ -78,7 +78,7 @@ public class XWikiGeneratorSink implements Sink
 
     private boolean isInVerbatim;
 
-    private StringBuffer accumulatedText = new StringBuffer();
+    private StringBuilder accumulatedText = new StringBuilder();
 
     /**
      * @since 3.0M3


### PR DESCRIPTION
I changed the variable from a StringBuffer to a StringBuilder. No other changes were needed as the methods used in the program work for both string classes.