### PR TITLE
[codestyle] declare parameter 'headerBlock' as org.xwiki.rendering.block.Block

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
@@ -49,7 +49,7 @@ public class TocBlockFilter extends PlainTextBlockFilter
      * @param headerBlock the section title.
      * @return the filtered label to use in toc anchor link.
      */
-    public List<Block> generateLabel(HeaderBlock headerBlock)
+    public List<Block> generateLabel (Block headerBlock)
     {
         return headerBlock.clone(this).getChildren();
     }


### PR DESCRIPTION
This is a fix for the issue at http://sonar.xwiki.org/issues/search#issues=930a5c9b-5704-41e7-befd-81484244699f.

My GCI task is:

https://codein.withgoogle.com/dashboard/task-instances/5241134932557824/