### PR TITLE
Fixed Sonar Issues in DefaultFigureTypeRecognizer

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/DefaultFigureTypeRecognizer.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/DefaultFigureTypeRecognizer.java
@@ -46,7 +46,7 @@ public class DefaultFigureTypeRecognizer implements FigureTypeRecognizer
     public boolean isTable(FigureBlock figureBlock)
     {
         List<Block> blocks = getBlocksIgnoringMacroMarkerBlocks(figureBlock.getChildren());
-        return (blocks.size() == 1 && blocks.get(0) instanceof TableBlock);
+        return blocks.size() == 1 && blocks.get(0) instanceof TableBlock;
     }
 
     private List<Block> getBlocksIgnoringMacroMarkerBlocks(List<Block> blocks)
@@ -57,7 +57,7 @@ public class DefaultFigureTypeRecognizer implements FigureTypeRecognizer
         for (Block block : blocks) {
             if (block instanceof MacroMarkerBlock) {
                 MacroMarkerBlock macroMarkerBlock = (MacroMarkerBlock) block;
-                if (macroMarkerBlock.getId().equals("figureCaption")) {
+                if ("figureCaption".equals(macroMarkerBlock.getId())) {
                     continue;
                 } else {
                     results.addAll(getBlocksIgnoringMacroMarkerBlocks(block.getChildren()));


### PR DESCRIPTION
Fixed all the issues in [this file](http://sonar.xwiki.org/dashboard/index?id=org.xwiki.rendering%3Axwiki-rendering-macro-figure%3Asrc%2Fmain%2Fjava%2Forg%2Fxwiki%2Frendering%2Finternal%2Fmacro%2Ffigure%2FDefaultFigureTypeRecognizer.java)

Solves Issues:
[Remove those useless parentheses](http://sonar.xwiki.org/issues/search#issues=fc0542e0-7aae-42b2-aa5b-883f244ef4c6) 

[Move the "figureCaption" string literal on the left side of this string comparison](http://sonar.xwiki.org/issues/search#issues=db82d5e0-27c6-4985-8dc4-bb7819307182)

[ Method org.xwiki.rendering.internal.macro.figure.DefaultFigureTypeRecognizer.getBlocksIgnoringMacro MarkerBlocks(List) makes literal string comparisons passing the literal as an argument
](http://sonar.xwiki.org/issues/search#issues=2369df49-720a-4750-9294-4fda3e150d5c)