### PR TITLE
Fixed all Strings literals on left issues

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ImageBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/ImageBlockParser.java
@@ -54,7 +54,7 @@ public class ImageBlockParser extends DefaultBlockParser
     protected void startElementInternal(String uri, String localName, String qName, Attributes attributes)
         throws SAXException
     {
-        if (qName.equals("reference")) {
+        if ("reference".equals(qName)) {
             setCurrentHandler(this.referenceParser);
         } else {
             super.startElementInternal(uri, localName, qName, attributes);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/LinkBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/LinkBlockParser.java
@@ -54,7 +54,7 @@ public class LinkBlockParser extends DefaultBlockParser
     protected void startElementInternal(String uri, String localName, String qName, Attributes attributes)
         throws SAXException
     {
-        if (qName.equals("reference")) {
+        if ("reference".equals(qName)) {
             setCurrentHandler(this.referenceParser);
         } else {
             super.startElementInternal(uri, localName, qName, attributes);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MetaDataBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/MetaDataBlockParser.java
@@ -60,7 +60,7 @@ public class MetaDataBlockParser extends DefaultBlockParser
     protected void startElementInternal(String uri, String localName, String qName, Attributes attributes)
         throws SAXException
     {
-        if (qName.equals("metaData")) {
+        if ("metaData".equals(qName)) {
             this.metaDataParser = new MetaDataParser(this.converter);
             setCurrentHandler(this.metaDataParser);
         } else {

--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataGenerator.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataGenerator.java
@@ -101,7 +101,7 @@ public class TestDataGenerator
                 // The reason these tests are not needed is because rendering is done from the XDOM and the event/1.0
                 // syntax is an exact representation of the XDOM object and thus we only need to check once the
                 // expected output (except for event/1.0).
-                if (inputCounter < 2 || !hasEventOutput || targetSyntaxId.equals("event/1.0")) {
+                if (inputCounter < 2 || !hasEventOutput || "event/1.0".equals(targetSyntaxId)) {
 
                     Object[] singleResult = new Object[8];
                     singleResult[0] = computeTestName(testResourceName, parserId, targetSyntaxId);
@@ -122,7 +122,7 @@ public class TestDataGenerator
 
                     result.add(singleResult);
 
-                    if (targetSyntaxId.equals("event/1.0")) {
+                    if ("event/1.0".equals(targetSyntaxId)) {
                         hasEventOutput = true;
                     }
                 }

--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
@@ -129,11 +129,11 @@ public class TestDataParser
     private void saveData(String action, StringBuffer buffer, TestData data, String keyName)
     {
         if (action != null) {
-            if (action.equalsIgnoreCase("input")) {
+            if ("input".equalsIgnoreCase(action)) {
                 saveBuffer(buffer, data.inputs, keyName);
-            } else if (action.equalsIgnoreCase("expect")) {
+            } else if ("expect".equalsIgnoreCase(action)) {
                 saveBuffer(buffer, data.expectations, keyName);
-            } else if (action.equalsIgnoreCase("inputexpect")) {
+            } else if ("inputexpect".equalsIgnoreCase(action)) {
                 saveBuffer(buffer, data.inputs, keyName);
                 saveBuffer(buffer, data.expectations, keyName);
             }

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/AbstractFormatTagHandler.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/AbstractFormatTagHandler.java
@@ -81,7 +81,7 @@ public abstract class AbstractFormatTagHandler extends TagHandler
                 String value = parameter.getValue();
 
                 if (currentParameter != null) {
-                    if (parameter.getKey().equals("style")) {
+                    if ("style".equals(parameter.getKey())) {
                         CSSStyleDeclarationImpl mergedStyle = mergeStyle(
                             currentStyle, currentParameter.getValue(),
                             parameter.getValue());
@@ -90,7 +90,7 @@ public abstract class AbstractFormatTagHandler extends TagHandler
                             value = mergedStyle.getCssText();
                             currentStyle = mergedStyle;
                         }
-                    } else if (parameter.getKey().equals("class")) {
+                    } else if ("class".equals(parameter.getKey())) {
                         value = mergeClass(currentParameter.getValue(),
                             parameter.getValue());
                     }

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/ReferenceTagHandler.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/ReferenceTagHandler.java
@@ -78,8 +78,8 @@ public class ReferenceTagHandler extends TagHandler
         // If so it means we have a free standing link.
         WikiParameter classParam = context.getParams().getParameter("class");
 
-        boolean isFreeStanding = ((classParam != null) && classParam.getValue().equalsIgnoreCase(
-            "wikimodel-freestanding"));
+        boolean isFreeStanding = ((classParam != null) && "wikimodel-freestanding".equalsIgnoreCase(
+            classParam.getValue()));
 
         if (isFreeStanding) {
             parameters = removeMeaningfulParameters(parameters);
@@ -93,8 +93,8 @@ public class ReferenceTagHandler extends TagHandler
     protected WikiParameters removeFreestanding(WikiParameters parameters)
     {
         WikiParameter classParam = parameters.getParameter("class");
-        boolean isFreeStanding = ((classParam != null) && classParam.getValue().equalsIgnoreCase(
-            "wikimodel-freestanding"));
+        boolean isFreeStanding = ((classParam != null) && "wikimodel-freestanding".equalsIgnoreCase(
+            classParam.getValue()));
         if (isFreeStanding) {
             parameters = parameters.remove("class");
         }


### PR DESCRIPTION
Fixed all issues in rendering for this rule: Strings literals should be placed on the left side when checking for equality
Solves: 
http://sonar.xwiki.org/issues/search#issues=94d88eaa-64b4-4e8d-99dc-712e4d462df6
http://sonar.xwiki.org/issues/search#issues=cad4d31e-b582-4744-bcab-0087f28408b4
http://sonar.xwiki.org/issues/search#issues=64748edd-ebd1-4ebe-bcdf-73af94121541
http://sonar.xwiki.org/issues/search#issues=4fc8f468-9189-4fcb-aee9-3b8391a0bdd7
http://sonar.xwiki.org/issues/search#issues=da91b94a-de95-4859-a276-9c5d7b437f8f
http://sonar.xwiki.org/issues/search#issues=4f0ab54a-aa97-4c9e-aff1-c5c319c34746
http://sonar.xwiki.org/issues/search#issues=2981b895-dc0e-424e-bfff-00a964e99c2d
http://sonar.xwiki.org/issues/search#issues=805dacf1-24e1-4d89-9313-23e087e0bdb2
http://sonar.xwiki.org/issues/search#issues=2ec07cca-a53a-435f-a14f-89f9be2b5070
http://sonar.xwiki.org/issues/search#issues=f673cef0-9f69-441c-9782-781b34d1eb4b
http://sonar.xwiki.org/issues/search#issues=69fc44f6-d1b5-4ae0-8d45-7008fbc5110b
http://sonar.xwiki.org/issues/search#issues=b75824ed-72eb-4d9e-97ff-9f7c34f601f8
