### PR TITLE
XRENDERING-523: Set the syntax in Macro Content

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/pom.xml
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/pom.xml
@@ -36,4 +36,13 @@
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Content Macro</xwiki.extension.name>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-syntax-html</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
@@ -91,18 +91,10 @@ public class ContentMacro extends AbstractMacro<ContentMacroParameters>
     {
         try {
             List<Block> blocks = getSyntaxParser(parameters.getSyntax()).parse(new StringReader(content)).getChildren();
+            MetaDataBlock metaDataBlock = new MetaDataBlock(blocks, MetaData.SYNTAX,
+                parameters.getSyntax().toIdString());
 
-            // if the result is only one metadata block, we put the syntax metadata in it
-            if (blocks.size() == 1 && blocks.get(0) instanceof MetaDataBlock) {
-                ((MetaDataBlock) blocks.get(0)).getMetaData()
-                    .addMetaData(MetaData.SYNTAX, parameters.getSyntax().toIdString());
-                return blocks;
-            // else we create a dedicated MetadataBlock
-            } else {
-                MetaDataBlock metaDataBlock = new MetaDataBlock(blocks, MetaData.SYNTAX,
-                    parameters.getSyntax().toIdString());
-                return Collections.singletonList(metaDataBlock);
-            }
+            return Collections.singletonList(metaDataBlock);
         } catch (ParseException e) {
             throw new MacroExecutionException(
                 String.format("Failed to parse macro content in syntax [%s]", parameters.getSyntax()), e);

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent3.test
@@ -3,18 +3,24 @@
 .input|xwiki/2.1
 .# Add XHTML content in XWiki Syntax 2.1 content
 .#-----------------------------------------------------
-{{content syntax="xhtml/1.0"}}
+{{content syntax="html/4.01"}}
 <p>test</p>
+<p>test2</p>
 {{/content}}
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
-beginMacroMarkerStandalone [content] [syntax=xhtml/1.0] [<p>test</p>]
-beginMetaData [[syntax]=[xhtml/1.0]]
+beginMacroMarkerStandalone [content] [syntax=html/4.01] [<p>test</p>
+<p>test2</p>]
+beginMetaData [[syntax]=[html/4.01]]
 beginParagraph
 onWord [test]
 endParagraph
-endMetaData [[syntax]=[xhtml/1.0]]
-endMacroMarkerStandalone [content] [syntax=xhtml/1.0] [<p>test</p>]
+beginParagraph
+onWord [test2]
+endParagraph
+endMetaData [[syntax]=[html/4.01]]
+endMacroMarkerStandalone [content] [syntax=html/4.01] [<p>test</p>
+<p>test2</p>]
 endDocument


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XRENDERING-523

## Changes

  * Set the syntax directly in the parent node as parameter, if there's
only one
  * Add a new metadatablock with the syntax if there's multiples blocks
  * Add a new test to check this latter case