### PR TITLE
XRENDERING-527: HTML renderer should handle metadata to create dedicated attribute

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -19,9 +19,10 @@
  */
 package org.xwiki.rendering.internal.renderer.xhtml;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.listener.MetaData;
@@ -36,8 +37,6 @@ import org.xwiki.rendering.listener.chaining.ListenerChain;
  */
 public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
 {
-    private static final String METADATA_BLOCK_ELEMENT = "span";
-
     /**
      * Renders a Macro definition into Annotated XHTML.
      */
@@ -88,24 +87,36 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
         }
     }
 
+    /**
+     * @return a span element if we are inside an inline macro. Else a div.
+     */
+    private String getMetadataContainerElement()
+    {
+        if (getBlockState().isInLine()) {
+            return "span";
+        } else {
+            return "div";
+        }
+    }
+
     @Override
     public void beginMetaData(MetaData metadata)
     {
-
-        Map<String, String> parameters = new HashMap<>();
+        Map<String, String> attributes = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> metadaPair : metadata.getMetaData().entrySet()) {
-            parameters.put(metadaPair.getKey(), metadaPair.getValue().toString());
+            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadaPair.getKey(),
+                metadaPair.getValue().toString());
         }
 
-        parameters.put("class", "xwiki-metadata-block");
+        attributes.put("class", XHTMLXWikiGeneratorListener.METADATA_CONTAINER_CLASS);
 
-        this.getXHTMLWikiPrinter().printXMLStartElement(METADATA_BLOCK_ELEMENT, parameters);
+        this.getXHTMLWikiPrinter().printXMLStartElement(getMetadataContainerElement(), attributes);
     }
 
     @Override
     public void endMetaData(MetaData metadata)
     {
-        getXHTMLWikiPrinter().printXMLEndElement(METADATA_BLOCK_ELEMENT);
+        getXHTMLWikiPrinter().printXMLEndElement(getMetadataContainerElement());
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -104,9 +104,9 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
     {
         Map<String, String> attributes = new LinkedHashMap<>();
 
-        for (Map.Entry<String, Object> metadaPair : metadata.getMetaData().entrySet()) {
-            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadaPair.getKey(),
-                metadaPair.getValue().toString());
+        for (Map.Entry<String, Object> metadataPair : metadata.getMetaData().entrySet()) {
+            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadataPair.getKey(),
+                metadataPair.getValue().toString());
         }
 
         attributes.put("class", XHTMLXWikiGeneratorListener.METADATA_CONTAINER_CLASS);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -19,10 +19,12 @@
  */
 package org.xwiki.rendering.internal.renderer.xhtml;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
+import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.listener.chaining.ListenerChain;
 
 /**
@@ -34,6 +36,8 @@ import org.xwiki.rendering.listener.chaining.ListenerChain;
  */
 public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
 {
+    private static final String METADATA_BLOCK_ELEMENT = "span";
+
     /**
      * Renders a Macro definition into Annotated XHTML.
      */
@@ -82,5 +86,26 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
             // so that the macro can be reconstructed when moving back from XHTML to XDOM.
             this.macroRenderer.endRender(getXHTMLWikiPrinter());
         }
+    }
+
+    @Override
+    public void beginMetaData(MetaData metadata)
+    {
+
+        Map<String, String> parameters = new HashMap<>();
+
+        for (Map.Entry<String, Object> metadaPair : metadata.getMetaData().entrySet()) {
+            parameters.put(metadaPair.getKey(), metadaPair.getValue().toString());
+        }
+
+        parameters.put("class", "xwiki-metadata-block");
+
+        this.getXHTMLWikiPrinter().printXMLStartElement(METADATA_BLOCK_ELEMENT, parameters);
+    }
+
+    @Override
+    public void endMetaData(MetaData metadata)
+    {
+        getXHTMLWikiPrinter().printXMLEndElement(METADATA_BLOCK_ELEMENT);
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/test/resources/annotatedxhtml10/simple/metadata/metadata1.out.txt
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/test/resources/annotatedxhtml10/simple/metadata/metadata1.out.txt
@@ -1,0 +1,1 @@
+<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/DefaultXWikiGeneratorListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/DefaultXWikiGeneratorListener.java
@@ -364,12 +364,17 @@ public class DefaultXWikiGeneratorListener implements XWikiGeneratorListener
         flushFormat();
 
         if (this.documentDepth > 0) {
-            getListener().beginGroup(convertParameters(params));
+            this.beginGroup(params);
         } else {
             getListener().beginDocument(this.documentMetadata);
         }
 
         ++this.documentDepth;
+    }
+
+    protected void beginGroup(WikiParameters params)
+    {
+        getListener().beginGroup(convertParameters(params));
     }
 
     @Override
@@ -555,10 +560,15 @@ public class DefaultXWikiGeneratorListener implements XWikiGeneratorListener
         --this.documentDepth;
 
         if (this.documentDepth > 0) {
-            getListener().endGroup(convertParameters(params));
+            this.endGroup(params);
         } else {
             getListener().endDocument(this.documentMetadata);
         }
+    }
+
+    protected void endGroup(WikiParameters parameters)
+    {
+        getListener().endGroup(convertParameters(parameters));
     }
 
     @Override

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
@@ -168,11 +168,8 @@ public class XHTMLXWikiGeneratorListener extends DefaultXWikiGeneratorListener
 
     private boolean isMetaDataElement(WikiParameters parameters)
     {
-        if (parameters.getParameter(CLASS_ATTRIBUTE) != null) {
-            return METADATA_CONTAINER_CLASS.equals(parameters.getParameter(CLASS_ATTRIBUTE).getValue());
-        }
-
-        return false;
+        return parameters.getParameter(CLASS_ATTRIBUTE) != null &&
+            METADATA_CONTAINER_CLASS.equals(parameters.getParameter(CLASS_ATTRIBUTE).getValue());
     }
 
     private MetaData createMetaData(WikiParameters parameters)

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/simple/metadata/metadata1.in.txt
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/simple/metadata/metadata1.in.txt
@@ -1,0 +1,1 @@
+<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/metadata/metadata1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/metadata/metadata1.test
@@ -1,0 +1,16 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<div class="xwiki-metadata-container" data-xwiki-syntax="xwiki/2.0">
+  <span>Heading</span>
+</div>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMetaData [[syntax]=[xwiki/2.0]]
+beginParagraph
+onWord [Heading]
+endParagraph
+endMetaData [[syntax]=[xwiki/2.0]]
+endDocument

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/metadata/metadata2.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/metadata/metadata2.test
@@ -1,0 +1,16 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<span class="xwiki-metadata-container" data-xwiki-syntax="xwiki/2.0">
+Heading
+</span>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+beginMetaData [[syntax]=[xwiki/2.0]]
+onWord [Heading]
+endMetaData [[syntax]=[xwiki/2.0]]
+endParagraph
+endDocument

--- a/xwiki-rendering-test/src/main/resources/cts/simple/metadata/metadata1.inout.xml
+++ b/xwiki-rendering-test/src/main/resources/cts/simple/metadata/metadata1.inout.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<document>
+  <p>
+    <metadata>
+      <metadata class="linked-hash-map">
+        <entry>
+          <string>syntax</string>
+          <org.xwiki.rendering.syntax.Syntax>
+            <type>
+              <name>${{{velocity:$syntax.type.name}}}</name>
+              <id>${{{velocity:$syntax.type.id}}}</id>
+            </type>
+            <version>${{{velocity:$syntax.version}}}</version>
+          </org.xwiki.rendering.syntax.Syntax>
+        </entry>
+      </metadata>
+    </metadata>
+  </p>
+  <metadata>
+    <p>
+      <metadata>
+        <metadata class="linked-hash-map">
+          <entry>
+            <string>syntax</string>
+            <string>xwiki/2.0</string>
+          </entry>
+        </metadata>
+      </metadata>
+    </p>
+    <group>
+      <paragraph>
+        <word>Heading</word>
+      </paragraph>
+    </group>
+  </metadata>
+</document>


### PR DESCRIPTION
  * Create a new dedicated block for metadata in
AnnotatedXHTMLChainingRenderer