### PR TITLE
XRENDERING-527: HTML renderer should handle metadata to create dedicated attribute

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
@@ -168,8 +168,8 @@ public class XHTMLXWikiGeneratorListener extends DefaultXWikiGeneratorListener
 
     private boolean isMetaDataElement(WikiParameters parameters)
     {
-        return parameters.getParameter(CLASS_ATTRIBUTE) != null &&
-            METADATA_CONTAINER_CLASS.equals(parameters.getParameter(CLASS_ATTRIBUTE).getValue());
+        return parameters.getParameter(CLASS_ATTRIBUTE) != null
+            && METADATA_CONTAINER_CLASS.equals(parameters.getParameter(CLASS_ATTRIBUTE).getValue());
     }
 
     private MetaData createMetaData(WikiParameters parameters)


### PR DESCRIPTION
Checked by running `mvn clean install -Pquality`. 