### PR TITLE
XRENDERING-518: Macro content editable inline

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro22.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro22.test
@@ -1,0 +1,35 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.# Test nested macro which can be edited inline, in block context.
+.#-----------------------------------------------------
+First paragraph.
+
+{{testnestedmacro /}}
+
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+onWord [First]
+onSpace
+onWord [paragraph]
+onSpecialSymbol [.]
+endParagraph
+beginMacroMarkerStandalone [testnestedmacro] []
+beginMacroMarkerStandalone [testsimplemacro] []
+beginParagraph
+onWord [simplemacro2]
+endParagraph
+endMacroMarkerStandalone [testsimplemacro] []
+endMacroMarkerStandalone [testnestedmacro] []
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<p>First paragraph.</p><p>simplemacro2</p>
+.#-----------------------------------------------------
+.expect|annotatedxhtml/1.0
+.#-----------------------------------------------------
+<p>First paragraph.</p><!--startmacro:testnestedmacro|-|--><!--startmacro:testsimplemacro|-|--><p>simplemacro2</p><!--stopmacro--><!--stopmacro-->

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -70,21 +70,17 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
     @Override
     public void beginMacroMarker(String name, Map<String, String> parameters, String content, boolean isInline)
     {
-        if (getBlockState().getMacroDepth() == 1) {
-            // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
-            // so that the macro can be reconstructed when moving back from XHTML to XDOM.
-            this.macroRenderer.beginRender(getXHTMLWikiPrinter(), name, parameters, content);
-        }
+        // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
+        // so that the macro can be reconstructed when moving back from XHTML to XDOM.
+        this.macroRenderer.beginRender(getXHTMLWikiPrinter(), name, parameters, content);
     }
 
     @Override
     public void endMacroMarker(String name, Map<String, String> parameters, String content, boolean isInline)
     {
-        if (getBlockState().getMacroDepth() == 1) {
-            // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
-            // so that the macro can be reconstructed when moving back from XHTML to XDOM.
-            this.macroRenderer.endRender(getXHTMLWikiPrinter());
-        }
+        // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
+        // so that the macro can be reconstructed when moving back from XHTML to XDOM.
+        this.macroRenderer.endRender(getXHTMLWikiPrinter());
     }
 
     /**


### PR DESCRIPTION
  * Macro marker are always printed for nested macros in annotatedxhtml