### PR TITLE
XRENDERING-518: The macro content descriptor should specify if it can be edited inline

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/java/org/xwiki/rendering/SimpleIntegrationTests.java
+++ b/xwiki-rendering-integration-tests/src/test/java/org/xwiki/rendering/SimpleIntegrationTests.java
@@ -20,8 +20,14 @@
 package org.xwiki.rendering;
 
 import org.junit.runner.RunWith;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.context.ExecutionContextManager;
+import org.xwiki.rendering.internal.transformation.MutableRenderingContext;
+import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.test.integration.RenderingTestSuite;
+import org.xwiki.rendering.transformation.RenderingContext;
 import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.mockito.MockitoComponentManager;
 
 /**
  * Run all tests found in {@code simple/*.test} files located in the classpath. These {@code *.test} files must follow
@@ -35,4 +41,17 @@ import org.xwiki.test.annotation.AllComponents;
 @AllComponents
 public class SimpleIntegrationTests
 {
+    @RenderingTestSuite.Initialized
+    public void initialize(MockitoComponentManager componentManager) throws Exception
+    {
+        ExecutionContext executionContext = new ExecutionContext();
+        ExecutionContextManager executionContextManager = componentManager.getInstance(ExecutionContextManager.class);
+        executionContextManager.initialize(executionContext);
+
+        // Set TargetSyntax for Macro tests
+        RenderingContext renderingContext = componentManager.getInstance(RenderingContext.class);
+        ((MutableRenderingContext) renderingContext).push(renderingContext.getTransformation(),
+            renderingContext.getXDOM(), renderingContext.getDefaultSyntax(), renderingContext.getTransformationId(),
+            renderingContext.isRestricted(), Syntax.XWIKI_2_0);
+    }
 }

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro20.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro20.test
@@ -37,7 +37,7 @@ onWord [paragraph]
 onSpecialSymbol [.]
 endParagraph
 onMacroStandalone [testcontentmacro] [] [{{testcontentmacro}}
-<p><strong>New content</strong></p>
+**New content**
 {{/testcontentmacro}}
 
 >line1


### PR DESCRIPTION
  * if no syntax metadata is available the fallback syntax is retrieved
from the RenderingContext#targetSyntax. If this latter is not available either, the final fallback is the parser syntax.