### PR TITLE
XRENDERING-518: The macro content descriptor should specify if it can be edited inline

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/InlineFilterListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/InlineFilterListener.java
@@ -54,4 +54,16 @@ public class InlineFilterListener extends WrappingListener
     {
         // Disable this event
     }
+
+    @Override
+    public void beginGroup(Map<String, String> parameters)
+    {
+        // Disable this event
+    }
+
+    @Override
+    public void endGroup(Map<String, String> parameters)
+    {
+        // Disable this event
+    }
 }


### PR DESCRIPTION
  * Also skip groups in InlineFilterListener