### PR TITLE
XRENDERING-518: The macro content descriptor should specify if it can be edited inline

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
@@ -49,6 +49,7 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
 {
     /**
      * All the macro that needs to display an unchanged content div around the content.
+     * // TODO: this nasty hack will be removed as soon as message macro is refactored to use the AbstractBoxMacro
      */
     private static final List<String> ACCEPTED_MACRO_UNCHANGED_CONTENT = Arrays.asList("box", "info", "error",
         "warning", "success");
@@ -80,7 +81,7 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
         // Don't execute transformations explicitly. They'll be executed on the generated content later on.
         List<Block> children = getMacroContentParser().parse(content, context, false, context.isInline()).getChildren();
 
-        // if we are really in the context of this macro, it's an unchanged content
+        // TODO: this nasty hack will be removed as soon as message macro is refactored to use the AbstractBoxMacro
         if (ACCEPTED_MACRO_UNCHANGED_CONTENT.contains(context.getCurrentMacroBlock().getId())) {
             return Collections.singletonList(new MetaDataBlock(children, this.getUnchangedContentMetaData()));
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rendering.internal.macro.box;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,6 +48,12 @@ import org.xwiki.rendering.transformation.MacroTransformationContext;
 public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMacro<P>
 {
     /**
+     * All the macro that needs to display an unchanged content div around the content.
+     */
+    private static final List<String> ACCEPTED_MACRO_UNCHANGED_CONTENT = Arrays.asList("box", "info", "error",
+        "warning", "success");
+
+    /**
      * The description of the macro.
      */
     private static final String DESCRIPTION = "Draw a box around provided content.";
@@ -74,7 +81,7 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
         List<Block> children = getMacroContentParser().parse(content, context, false, context.isInline()).getChildren();
 
         // if we are really in the context of this macro, it's an unchanged content
-        if (context.getCurrentMacroBlock().getId().equals("box")) {
+        if (ACCEPTED_MACRO_UNCHANGED_CONTENT.contains(context.getCurrentMacroBlock().getId())) {
             return Collections.singletonList(new MetaDataBlock(children, this.getUnchangedContentMetaData()));
 
         // else we cannot guarantee it

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.rendering.internal.macro.message;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -27,7 +26,6 @@ import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.rendering.block.Block;
-import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.macro.AbstractMacro;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.MacroExecutionException;
@@ -79,10 +77,7 @@ public abstract class AbstractMessageMacro extends AbstractMacro<Object>
 
         boxParameters.setCssClass(context.getCurrentMacroBlock().getId() + "message");
 
-        return Collections.singletonList(
-            new MetaDataBlock(this.boxMacro.execute(boxParameters, content, context),
-                this.getUnchangedContentMetaData())
-        );
+        return this.boxMacro.execute(boxParameters, content, context);
     }
 
     @Override

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -77,6 +77,7 @@ public abstract class AbstractMessageMacro extends AbstractMacro<Object>
 
         boxParameters.setCssClass(context.getCurrentMacroBlock().getId() + "message");
 
+        // TODO: we should not rely directly on the concrete macro, but only on the AbstractBoxMacro
         return this.boxMacro.execute(boxParameters, content, context);
     }
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
@@ -16,8 +16,8 @@ beginMacroMarkerStandalone [info] [] [Failed to do this action. The correct poss
 * use another value
 * you don't have right
 * another possibility]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginGroup [[class]=[box infomessage]]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,8 +64,8 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endGroup [[class]=[box infomessage]]
 endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [Failed to do this action. The correct possibilities are:
 * use another value
 * you don't have right

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
@@ -16,8 +16,8 @@ beginMacroMarkerStandalone [warning] [] [Failed to do this action. The correct p
 * use another value
 * you don't have right
 * another possibility]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginGroup [[class]=[box warningmessage]]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,8 +64,8 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endGroup [[class]=[box warningmessage]]
 endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endGroup [[class]=[box warningmessage]]
 endMacroMarkerStandalone [warning] [] [Failed to do this action. The correct possibilities are:
 * use another value
 * you don't have right

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
@@ -16,8 +16,8 @@ beginMacroMarkerStandalone [error] [] [Failed to do this action. The correct pos
 * use another value
 * you don't have right
 * another possibility]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginGroup [[class]=[box errormessage]]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,8 +64,8 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endGroup [[class]=[box errormessage]]
 endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endGroup [[class]=[box errormessage]]
 endMacroMarkerStandalone [error] [] [Failed to do this action. The correct possibilities are:
 * use another value
 * you don't have right

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
@@ -13,8 +13,8 @@
 beginDocument
 beginMacroMarkerStandalone [info] [] [* item1
 * item2]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginGroup [[class]=[box infomessage]]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginList [BULLETED]
 beginListItem
 onWord [item1]
@@ -23,8 +23,8 @@ beginListItem
 onWord [item2]
 endListItem
 endList [BULLETED]
-endGroup [[class]=[box infomessage]]
 endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [* item1
 * item2]
 endDocument


### PR DESCRIPTION
  * Fix the macro message to put the unchanged content at the right
place