### PR TITLE
XRENDERING-538: Figure and FigureCaption macros should be editable inline

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
@@ -30,6 +30,7 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.FigureBlock;
 import org.xwiki.rendering.block.FigureCaptionBlock;
+import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.macro.AbstractNoParameterMacro;
 import org.xwiki.rendering.macro.MacroContentParser;
@@ -92,7 +93,8 @@ public class FigureCaptionMacro extends AbstractNoParameterMacro
             XDOM xdom = this.contentParser.parse(content, context, false, false);
             List<Block> figureCaptionChildren = xdom.getChildren();
             this.parserUtils.removeTopLevelParagraph(figureCaptionChildren);
-            result = Collections.singletonList(new FigureCaptionBlock(figureCaptionChildren));
+            figureCaptionChildren = Collections.singletonList(new FigureCaptionBlock(figureCaptionChildren));
+            result = Collections.singletonList(new MetaDataBlock(figureCaptionChildren, getUnchangedContentMetaData()));
         }
 
         return result;

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.FigureBlock;
+import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.macro.AbstractNoParameterMacro;
 import org.xwiki.rendering.macro.MacroContentParser;
@@ -81,6 +82,9 @@ public class FigureMacro extends AbstractNoParameterMacro
         throws MacroExecutionException
     {
         XDOM xdom = this.contentParser.parse(content, context, false, false);
-        return Collections.singletonList(new FigureBlock(xdom.getChildren()));
+        List<Block> contentBlock = Collections.singletonList(new FigureBlock(xdom.getChildren()));
+
+        // mark the figure as editable inline
+        return Collections.singletonList(new MetaDataBlock(contentBlock, this.getUnchangedContentMetaData()));
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
@@ -16,11 +16,14 @@ beginMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption
 
 whatever1
 whatever2]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginMacroMarkerStandalone [figureCaption] [] [caption]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigureCaption
 onWord [caption]
 endFigureCaption
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figureCaption] [] [caption]
 beginParagraph
 onWord [whatever1]
@@ -28,6 +31,7 @@ onNewLine
 onWord [whatever2]
 endParagraph
 endFigure
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption}}
 
 whatever1

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
@@ -16,6 +16,7 @@ beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 
 {{figureCaption}}caption{{/figureCaption}}]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginParagraph
 onWord [whatever1]
@@ -23,11 +24,14 @@ onNewLine
 onWord [whatever2]
 endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigureCaption
 onWord [caption]
 endFigureCaption
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figureCaption] [] [caption]
 endFigure
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
@@ -12,6 +12,7 @@ whatever2
 beginDocument
 beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginParagraph
 onWord [whatever1]
@@ -19,6 +20,7 @@ onNewLine
 onWord [whatever2]
 endParagraph
 endFigure
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
 endDocument


### PR DESCRIPTION

  * Allow figure and FigureCaption to be editable inline. Change tests
accordingly.