### PR TITLE
XRENDERING-518: The macro content descriptor should specify if it can be edited inline

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Represents a set of MetaData.
  *
@@ -62,6 +64,7 @@ public class MetaData
      *
      * @since 10.10RC1
      */
+    @Unstable
     public static final String UNCHANGED_CONTENT = "unchanged-content";
 
     /**

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
@@ -34,6 +34,7 @@ import org.xwiki.rendering.macro.descriptor.ContentDescriptor;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.descriptor.DefaultMacroDescriptor;
 import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
+import org.xwiki.stability.Unstable;
 
 /**
  * Helper to implement Macro, providing some default implementation. We recommend Macro writers to extend this class.
@@ -261,6 +262,7 @@ public abstract class AbstractMacro<P> implements Macro<P>, Initializable
      *
      * @since 10.10RC1
      */
+    @Unstable
     protected MetaData getUnchangedContentMetaData()
     {
         MetaData metaData = new MetaData();


### PR DESCRIPTION
  * Add missing unstable annotations