### PR TITLE
XRENDERING-541: You can no longer insert content to inlinemacro without selecting beforehand

### DIFF
--- a/xwiki-rendering-integration-tests/pom.xml
+++ b/xwiki-rendering-integration-tests/pom.xml
@@ -133,6 +133,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-macro-box</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro25.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro25.test
@@ -1,0 +1,22 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test that an empty box with empty content gets an unchanged content div
+.#-----------------------------------------------------
+<!--startmacro:box|-||-|-->
+<!--stopmacro-->
+.#-----------------------------------------------------
+.expect|annotatedxhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:box|-||-|--><div class="box"><div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"></div></div><!--stopmacro-->
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [box] [] []
+beginGroup [[class]=[box]]
+beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endGroup [[class]=[box]]
+endMacroMarkerStandalone [box] [] []
+endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro26.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro26.test
@@ -1,0 +1,18 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test that an empty box with a NULL content does NOT get an unchanged content div
+.#-----------------------------------------------------
+<!--startmacro:box|-|-->
+<!--stopmacro-->
+.#-----------------------------------------------------
+.expect|annotatedxhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:box|-|--><!--stopmacro-->
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [box] []
+endMacroMarkerStandalone [box] []
+endDocument


### PR DESCRIPTION
  * Ensure the behaviour of box macro with empty or null content for
inline editing