### PR TITLE
XRENDERING-539: Change the "unchanged-content" metadata name

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
@@ -60,12 +60,12 @@ public class MetaData
     public static final String BASE = "base";
 
     /**
-     * Represents an inline editable content.
+     * Represents a non generated content: a content that has not been transformed in any way.
      *
-     * @since 10.10RC1
+     * @since 10.10
      */
     @Unstable
-    public static final String UNCHANGED_CONTENT = "unchanged-content";
+    public static final String NON_GENERATED_CONTENT = "non-generated-content";
 
     /**
      * Contains all MetaData for this Block and its children. Note: we preserve the order of metadata elements as they

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro16.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro16.test
@@ -19,11 +19,11 @@ onWord [paragraph]
 onSpecialSymbol [.]
 endParagraph
 beginMacroMarkerStandalone [testinlineeditingmacro] [] [Some content]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Some content]
 endParagraph
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [testinlineeditingmacro] [] [Some content]
 endDocument
 .#-----------------------------------------------------
@@ -33,7 +33,7 @@ endDocument
 .#-----------------------------------------------------
 .expect|annotatedxhtml/1.0
 .#-----------------------------------------------------
-<p>First paragraph.</p><!--startmacro:testinlineeditingmacro|-||-|Some content--><div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"><p>Some content</p></div><!--stopmacro-->
+<p>First paragraph.</p><!--startmacro:testinlineeditingmacro|-||-|Some content--><div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"><p>Some content</p></div><!--stopmacro-->
 .#-----------------------------------------------------
 .expect|xwiki/2.0
 .#-----------------------------------------------------

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro17.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro17.test
@@ -7,7 +7,7 @@
 <div>
 Some data to ignore
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
 <strong>New content</strong>
 </div>
 <div>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro18.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro18.test
@@ -5,7 +5,7 @@
 .#-----------------------------------------------------
 <p>First
 <!--startmacro:testcontentmacro|-||-|Old content-->
-<span>Some data to ignore</span><span data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><strong>New content</strong></span><span>Some other data</span>
+<span>Some data to ignore</span><span data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><strong>New content</strong></span><span>Some other data</span>
 <!--stopmacro-->
 paragraph.</p>
 

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro19.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro19.test
@@ -6,9 +6,9 @@
 <p>First
 <!--startmacro:testcontentmacro|-||-|Old content-->
 <span>Some data to ignore</span>
-<span data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
+<span data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
 <!--startmacro:testcontentmacro|-||-|Old content-->
-<span>Some data to ignore</span><span data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container"><strong>New content</strong></span><span>Some other data</span>
+<span>Some data to ignore</span><span data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container"><strong>New content</strong></span><span>Some other data</span>
 <!--stopmacro--></span><span>Some other data</span>
 <!--stopmacro-->
 paragraph.</p>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro20.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro20.test
@@ -7,12 +7,12 @@
 <div>
 Some data to ignore
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
 <!--startmacro:testcontentmacro|-||-|Old content-->
 <div>
 Some data to ignore 2
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
 <strong>New content</strong>
 </div>
 <div>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro21.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro21.test
@@ -1,14 +1,14 @@
 .#-----------------------------------------------------
 .input|xhtml/1.0
-.# Test nested macro with an unchanged content in the children macro which need to be ignored as its parent doesn't say it's an unchanged content.
+.# Test nested macro with a non generated content in the children macro which need to be ignored as its parent doesn't say it's a non generated content.
 .#-----------------------------------------------------
 <p>First paragraph.</p>
 <!--startmacro:testcontentmacro|-||-|First content-->
 <div>
 Some data to ignore
 <!--startmacro:testcontentmacro|-||-|Second content-->
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
-<strong>Content ignored because the top macro doesn't have an unchanged content</strong>
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container">
+<strong>Content ignored because the top macro doesn't have a non generated content</strong>
 </div>
 <!--stopmacro-->
 </div>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro23.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro23.test
@@ -7,11 +7,11 @@
 
 <!--startmacro:info|-||-|whatever-->
 <div class="box infomessage">
-  <div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
+  <div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
     <p>one</p>
     <!--startmacro:error|-||-|whatever-->
     <div class="box errormessage">
-      <div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
+      <div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
         <p>two</p>
       </div>
     </div>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro24.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro24.test
@@ -5,7 +5,7 @@
 .#-----------------------------------------------------
 <p>before</p>
 <!--startmacro:info|-||-|test-->
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
   <div class="box infomessage">
     <p>one <strong>two</strong> three</p>
   </div>

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro25.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro25.test
@@ -1,22 +1,22 @@
 .runTransformations
 .#-----------------------------------------------------
 .input|xhtml/1.0
-.# Test that an empty box with empty content gets an unchanged content div
+.# Test that an empty box with empty content gets a non generated content div
 .#-----------------------------------------------------
 <!--startmacro:box|-||-|-->
 <!--stopmacro-->
 .#-----------------------------------------------------
 .expect|annotatedxhtml/1.0
 .#-----------------------------------------------------
-<!--startmacro:box|-||-|--><div class="box"><div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"></div></div><!--stopmacro-->
+<!--startmacro:box|-||-|--><div class="box"><div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"></div></div><!--stopmacro-->
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
 beginMacroMarkerStandalone [box] [] []
 beginGroup [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [box] [] []
 endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro26.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro26.test
@@ -1,7 +1,7 @@
 .runTransformations
 .#-----------------------------------------------------
 .input|xhtml/1.0
-.# Test that an empty box with a NULL content does NOT get an unchanged content div
+.# Test that an empty box with a NULL content does NOT get a non generated content div
 .#-----------------------------------------------------
 <!--startmacro:box|-|-->
 <!--stopmacro-->

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
@@ -73,6 +73,6 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
         // Don't execute transformations explicitly. They'll be executed on the generated content later on.
         List<Block> children = getMacroContentParser().parse(content, context, false, context.isInline()).getChildren();
 
-        return Collections.singletonList(new MetaDataBlock(children, this.getUnchangedContentMetaData()));
+        return Collections.singletonList(new MetaDataBlock(children, this.getNonGeneratedContentMetaData()));
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/macro/box/MandatoryContentBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/macro/box/MandatoryContentBoxMacro.java
@@ -57,7 +57,7 @@ public class MandatoryContentBoxMacro extends AbstractBoxMacro<BoxMacroParameter
     {
         return Collections.singletonList(new MetaDataBlock(
             Collections.<Block>singletonList(new VerbatimBlock(content, context.isInline())),
-            this.getUnchangedContentMetaData()
+            this.getNonGeneratedContentMetaData()
         ));
     }
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/macro/box/TestBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/macro/box/TestBoxMacro.java
@@ -56,7 +56,7 @@ public class TestBoxMacro extends AbstractBoxMacro<BoxMacroParameters>
     {
         return Collections.singletonList(new MetaDataBlock(
             Collections.<Block>singletonList(new VerbatimBlock(content, context.isInline())),
-            this.getUnchangedContentMetaData()
+            this.getNonGeneratedContentMetaData()
         ));
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox1.test
@@ -13,7 +13,7 @@ beginDocument
 beginMacroMarkerStandalone [box] [] [* one
 * two]
 beginGroup [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginList [BULLETED]
 beginListItem
 onWord [one]
@@ -22,7 +22,7 @@ beginListItem
 onWord [two]
 endListItem
 endList [BULLETED]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [box] [] [* one
 * two]

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox2.test
@@ -14,11 +14,11 @@ onWord [inline]
 onSpace
 beginMacroMarkerInline [box] [] [**box**]
 beginFormat [NONE] [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFormat [BOLD]
 onWord [box]
 endFormat [BOLD]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endFormat [NONE] [[class]=[box]]
 endMacroMarkerInline [box] [] [**box**]
 endParagraph

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox3.test
@@ -12,9 +12,9 @@ content
 beginDocument
 beginMacroMarkerStandalone [testbox] [] [content]
 beginGroup [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 onVerbatim [content] [false]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [testbox] [] [content]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox4.test
@@ -10,9 +10,9 @@
 beginDocument
 beginMacroMarkerStandalone [testbox] [] []
 beginGroup [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 onVerbatim [] [false]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [testbox] [] []
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox5.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox5.test
@@ -14,11 +14,11 @@ onNewLine
 beginLink [Typed = [false] Type = [url] Reference = [http://www.xwiki.org]] [false]
 onWord [XWiki]
 endLink [Typed = [false] Type = [url] Reference = [http://www.xwiki.org]] [false]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [alabala]
 endParagraph
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box myCLASS]]
 endMacroMarkerStandalone [box] [title=[[XWiki>>http://www.xwiki.org]]|cssClass=myCLASS|image=http://l.yimg.com/i/i/fr/tr/usa4.jpg] [alabala]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox6.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox6.test
@@ -14,12 +14,12 @@ onWord [An]
 onSpace
 beginMacroMarkerInline [box] [] [Inline box ]
 beginFormat [NONE] [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 onWord [Inline]
 onSpace
 onWord [box]
 onSpace
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endFormat [NONE] [[class]=[box]]
 endMacroMarkerInline [box] [] [Inline box ]
 onSpace
@@ -27,7 +27,7 @@ onWord [first]
 endParagraph
 beginMacroMarkerStandalone [box] [] [A box that should not be inline]
 beginGroup [[class]=[box]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [A]
 onSpace
@@ -43,7 +43,7 @@ onWord [be]
 onSpace
 onWord [inline]
 endParagraph
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [box] [] [A box that should not be inline]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox7.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox7.test
@@ -10,11 +10,11 @@
 beginDocument
 beginMacroMarkerStandalone [box] [width=100px] [something]
 beginGroup [[class]=[box][style]=[width:100px]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [something]
 endParagraph
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box][style]=[width:100px]]
 endMacroMarkerStandalone [box] [width=100px] [something]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox8.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox8.test
@@ -1,7 +1,7 @@
 .runTransformations
 .#-----------------------------------------------------
 .input|xwiki/2.0
-.# Test that custom box reusing box, will also put unchanged content metadata
+.# Test that custom box reusing box, will also put non generated content metadata
 .#-----------------------------------------------------
 {{custombox}}something{{/custombox}}
 .#-----------------------------------------------------
@@ -11,8 +11,8 @@ beginDocument
 beginMacroMarkerStandalone [custombox] [] [something]
 beginGroup [[class]=[box]]
 onWord [something]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]
 endMacroMarkerStandalone [custombox] [] [something]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
@@ -95,7 +95,7 @@ public class ContentMacro extends AbstractMacro<ContentMacroParameters>
             MetaDataBlock metaDataBlock = new MetaDataBlock(blocks, MetaData.SYNTAX,
                 parameters.getSyntax().toIdString());
 
-            metaDataBlock.getMetaData().addMetaData(this.getUnchangedContentMetaData());
+            metaDataBlock.getMetaData().addMetaData(this.getNonGeneratedContentMetaData());
             return Collections.singletonList(metaDataBlock);
         } catch (ParseException e) {
             throw new MacroExecutionException(

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent1.test
@@ -11,10 +11,10 @@
 .#-----------------------------------------------------
 beginDocument
 beginMacroMarkerStandalone [content] [syntax=xhtml/1.0] [<p>test</p>]
-beginMetaData [[syntax]=[xhtml/1.0][unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][syntax]=[xhtml/1.0]]
 beginParagraph
 onWord [test]
 endParagraph
-endMetaData [[syntax]=[xhtml/1.0][unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][syntax]=[xhtml/1.0]]
 endMacroMarkerStandalone [content] [syntax=xhtml/1.0] [<p>test</p>]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent3.test
@@ -13,14 +13,14 @@
 beginDocument
 beginMacroMarkerStandalone [content] [syntax=html/4.01] [<p>test</p>
 <p>test2</p>]
-beginMetaData [[syntax]=[html/4.01][unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][syntax]=[html/4.01]]
 beginParagraph
 onWord [test]
 endParagraph
 beginParagraph
 onWord [test2]
 endParagraph
-endMetaData [[syntax]=[html/4.01][unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][syntax]=[html/4.01]]
 endMacroMarkerStandalone [content] [syntax=html/4.01] [<p>test</p>
 <p>test2</p>]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
@@ -96,7 +96,8 @@ public class FigureCaptionMacro extends AbstractNoParameterMacro
             figureCaptionChildren = Collections.singletonList(new FigureCaptionBlock(figureCaptionChildren));
 
             // Mark the macro content as being content that has not been transformed (so that it can editable inline)
-            result = Collections.singletonList(new MetaDataBlock(figureCaptionChildren, getUnchangedContentMetaData()));
+            result = Collections.singletonList(new MetaDataBlock(figureCaptionChildren,
+                getNonGeneratedContentMetaData()));
         }
 
         return result;

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
@@ -85,6 +85,6 @@ public class FigureMacro extends AbstractNoParameterMacro
         List<Block> contentBlock = Collections.singletonList(new FigureBlock(xdom.getChildren()));
 
         // Mark the macro content as being content that has not been transformed (so that it can editable inline)
-        return Collections.singletonList(new MetaDataBlock(contentBlock, getUnchangedContentMetaData()));
+        return Collections.singletonList(new MetaDataBlock(contentBlock, getNonGeneratedContentMetaData()));
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
@@ -16,14 +16,14 @@ beginMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption
 
 whatever1
 whatever2]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginMacroMarkerStandalone [figureCaption] [] [caption]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigureCaption
 onWord [caption]
 endFigureCaption
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figureCaption] [] [caption]
 beginParagraph
 onWord [whatever1]
@@ -31,7 +31,7 @@ onNewLine
 onWord [whatever2]
 endParagraph
 endFigure
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption}}
 
 whatever1

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
@@ -16,7 +16,7 @@ beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 
 {{figureCaption}}caption{{/figureCaption}}]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginParagraph
 onWord [whatever1]
@@ -24,14 +24,14 @@ onNewLine
 onWord [whatever2]
 endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigureCaption
 onWord [caption]
 endFigureCaption
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figureCaption] [] [caption]
 endFigure
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
@@ -12,7 +12,7 @@ whatever2
 beginDocument
 beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginFigure
 beginParagraph
 onWord [whatever1]
@@ -20,7 +20,7 @@ onNewLine
 onWord [whatever2]
 endParagraph
 endFigure
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -62,7 +62,7 @@ public abstract class AbstractMessageMacro extends AbstractBoxMacro<BoxMacroPara
     {
         List<Block> macroContent = getMacroContentParser().parse(content, context, false, context.isInline())
             .getChildren();
-        return Collections.singletonList(new MetaDataBlock(macroContent, this.getUnchangedContentMetaData()));
+        return Collections.singletonList(new MetaDataBlock(macroContent, this.getNonGeneratedContentMetaData()));
     }
 
     @Override

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
@@ -17,7 +17,7 @@ beginMacroMarkerStandalone [info] [] [Failed to do this action. The correct poss
 * you don't have right
 * another possibility]
 beginGroup [[class]=[box infomessage]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,7 +64,7 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
@@ -17,7 +17,7 @@ beginMacroMarkerStandalone [warning] [] [Failed to do this action. The correct p
 * you don't have right
 * another possibility]
 beginGroup [[class]=[box warningmessage]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,7 +64,7 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box warningmessage]]
 endMacroMarkerStandalone [warning] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
@@ -17,7 +17,7 @@ beginMacroMarkerStandalone [error] [] [Failed to do this action. The correct pos
 * you don't have right
 * another possibility]
 beginGroup [[class]=[box errormessage]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [Failed]
 onSpace
@@ -64,7 +64,7 @@ onSpace
 onWord [possibility]
 endListItem
 endList [BULLETED]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box errormessage]]
 endMacroMarkerStandalone [error] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
@@ -14,7 +14,7 @@ beginDocument
 beginMacroMarkerStandalone [info] [] [* item1
 * item2]
 beginGroup [[class]=[box infomessage]]
-beginMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginList [BULLETED]
 beginListItem
 onWord [item1]
@@ -23,7 +23,7 @@ beginListItem
 onWord [item2]
 endListItem
 endList [BULLETED]
-endMetaData [[unchanged-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [* item1
 * item2]

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
@@ -117,12 +117,12 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
     {
         boolean shouldIgnoreAll;
 
-        // true if we are already in an unchanged content block
-        boolean inUnchangedContent = stack.getStackParameter(UNCHANGED_CONTENT_STACK) != null
-            && (Boolean) stack.getStackParameter(UNCHANGED_CONTENT_STACK);
+        // true if we are already in a non generated content block
+        boolean inNonGeneratedContent = stack.getStackParameter(NON_GENERATED_CONTENT_STACK) != null
+            && (Boolean) stack.getStackParameter(NON_GENERATED_CONTENT_STACK);
 
-        // if we are in a macro but not in an unchanged content, we should ignore all
-        if (stack.getStackParameter(MACRO_INFO) != null && !inUnchangedContent) {
+        // if we are in a macro but not in a non generated content, we should ignore all
+        if (stack.getStackParameter(MACRO_INFO) != null && !inNonGeneratedContent) {
             shouldIgnoreAll = true;
         } else {
             shouldIgnoreAll = false;
@@ -135,13 +135,13 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
         if (shouldIgnoreAll) {
             stack.setIgnoreElements();
 
-        // we ignore elements until we get an unchanged content: then the rule will be deactivated
+        // we ignore elements until we get a non generated content: then the rule will be deactivated
         // see IgnoreElementRule
         } else {
             stack.pushIgnoreElementRule(new IgnoreElementRule(tagContext -> {
                 WikiParameters wikiParameters = tagContext.getParams();
                 if (wikiParameters != null) {
-                    return wikiParameters.getParameter(METADATA_ATTRIBUTE_PREFIX + MetaData.UNCHANGED_CONTENT) != null;
+                    return wikiParameters.getParameter(METADATA_ATTRIBUTE_PREFIX + MetaData.NON_GENERATED_CONTENT) != null;
                 }
                 return false;
             }, true));

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiDivTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiDivTagHandler.java
@@ -26,7 +26,7 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 import org.xwiki.stability.Unstable;
 
 /**
- * The div might contain an unchanged content metadata which needs a specific processing.
+ * The div might contain a non generated content metadata which needs a specific processing.
  *
  * @version $Id$
  * @since 10.10RC1
@@ -40,7 +40,7 @@ public class XWikiDivTagHandler extends DivisionTagHandler implements XWikiWikiM
      * Default constructor of a {@link XWikiDivTagHandler}.
      *
      * @param documentClass used by {@link DivisionTagHandler}
-     * @param componentManager is used to retrieved the proper parser component for serializing an unchanged content
+     * @param componentManager is used to retrieved the proper parser component for serializing a non generated content
      * @param parser the current parser is actually used to simplify the build of other parsers.
      */
     public XWikiDivTagHandler(String documentClass, ComponentManager componentManager, XHTMLParser parser)
@@ -52,15 +52,15 @@ public class XWikiDivTagHandler extends DivisionTagHandler implements XWikiWikiM
     @Override
     protected void begin(TagContext context)
     {
-        boolean withUnchangedContent = this.xWikiMacroHandler.handleBegin(context);
+        boolean withNonGeneratedContent = this.xWikiMacroHandler.handleBegin(context);
 
         // we only go through the element if we're not in a macro, or we are in a potentially new content
-        if (!withUnchangedContent) {
+        if (!withNonGeneratedContent) {
             super.begin(context);
 
             // in case of beginDocument we use a new stack of parameter, so we need to put in it the
-            // UNCHANGED_CONTENT_STACK value, as it will be popped in end()
-            context.getTagStack().pushStackParameter(UNCHANGED_CONTENT_STACK, false);
+            // NON_GENERATED_CONTENT_STACK value, as it will be popped in end()
+            context.getTagStack().pushStackParameter(NON_GENERATED_CONTENT_STACK, false);
         }
     }
 
@@ -68,14 +68,14 @@ public class XWikiDivTagHandler extends DivisionTagHandler implements XWikiWikiM
     @Override
     protected void end(TagContext context)
     {
-        boolean unchangedContent = this.xWikiMacroHandler.handleEnd(context);
+        boolean nonGeneratedContent = this.xWikiMacroHandler.handleEnd(context);
 
-        if (!unchangedContent) {
+        if (!nonGeneratedContent) {
             super.end(context);
 
-            // we still have one unchanged content value in the context,
+            // we still have one non generated content value in the context,
             // we remove it to be consistent
-            context.getTagStack().popStackParameter(UNCHANGED_CONTENT_STACK);
+            context.getTagStack().popStackParameter(NON_GENERATED_CONTENT_STACK);
         }
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
@@ -92,17 +92,17 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
     }
 
     /**
-     * Handle the begin of a container element (div or span) which could contain a syntax metadata and/or an unchanged
-     * content metadata.
+     * Handle the begin of a container element (div or span) which could contain a syntax metadata and/or a non 
+     * generated content metadata.
      * @param context the current tag context.
-     * @return true if an unchanged content metadata has been found or the macro info is not null.
+     * @return true if a non generated content metadata has been found or the macro info is not null.
      */
     public boolean handleBegin(TagContext context)
     {
         WikiParameters params = context.getParams();
         MacroInfo macroInfo = (MacroInfo) context.getTagStack().getStackParameter(MACRO_INFO);
 
-        boolean withUnchangedContent = false;
+        boolean withNonGeneratedContent = false;
         if (isMetaDataElement(params)) {
             MetaData metaData = createMetaData(params);
 
@@ -111,7 +111,7 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
                 context.getTagStack().pushStackParameter(CURRENT_SYNTAX, currentSyntax);
             }
 
-            if (metaData.contains(MetaData.UNCHANGED_CONTENT)) {
+            if (metaData.contains(MetaData.NON_GENERATED_CONTENT)) {
                 String currentSyntaxParameter = this.getSyntax(context);
                 try {
                     PrintRenderer renderer = this.componentManager.getInstance(PrintRenderer.class,
@@ -131,7 +131,7 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
 
                     context.getTagStack().pushScannerContext(new WikiScannerContext(xWikiGeneratorListener));
                     context.getTagStack().getScannerContext().beginDocument();
-                    withUnchangedContent = true;
+                    withNonGeneratedContent = true;
                 } catch (ComponentLookupException e) {
                     this.logger.error("Error while getting the appropriate renderer for syntax [{}]",
                         currentSyntaxParameter, e);
@@ -139,21 +139,21 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
             }
         }
 
-        context.getTagStack().pushStackParameter(UNCHANGED_CONTENT_STACK, withUnchangedContent);
-        return withUnchangedContent || macroInfo != null;
+        context.getTagStack().pushStackParameter(NON_GENERATED_CONTENT_STACK, withNonGeneratedContent);
+        return withNonGeneratedContent || macroInfo != null;
     }
 
     /**
-     * Handle the end of a container (div or span) which can contain unchanged content metadata.
+     * Handle the end of a container (div or span) which can contain a non generated content metadata.
      * @param context the context of the current tag.
-     * @return true if an unchanged content tag has been detected or it's in an macro info.
+     * @return true if a non generated content tag has been detected or it's in an macro info.
      */
     public boolean handleEnd(TagContext context)
     {
-        boolean unchangedContent = (boolean) context.getTagStack().popStackParameter(UNCHANGED_CONTENT_STACK);
+        boolean nonGeneratedContent = (boolean) context.getTagStack().popStackParameter(NON_GENERATED_CONTENT_STACK);
         MacroInfo macroInfo = (MacroInfo) context.getTagStack().getStackParameter(MACRO_INFO);
 
-        if (unchangedContent) {
+        if (nonGeneratedContent) {
             context.getTagStack().getScannerContext().endDocument();
 
             XWikiGeneratorListener xWikiGeneratorListener =
@@ -171,6 +171,6 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
             macroInfo.setContent(content);
         }
 
-        return unchangedContent || macroInfo != null;
+        return nonGeneratedContent || macroInfo != null;
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiSpanTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiSpanTagHandler.java
@@ -41,7 +41,7 @@ public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiMode
     /**
      * Default constructor of a {@link XWikiSpanTagHandler}.
      *
-     * @param componentManager is used to retrieved the proper parser component for serializing an unchanged content
+     * @param componentManager is used to retrieved the proper parser component for serializing a non generated content
      * @param parser the current parser is actually used to simplify the build of other parsers.
      * @since 10.10RC1
      */
@@ -54,10 +54,10 @@ public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiMode
     protected void begin(TagContext context)
     {
         WikiParameters params = context.getParams();
-        boolean withUnchangedContent = this.xWikiMacroHandler.handleBegin(context);
+        boolean withNonGeneratedContent = this.xWikiMacroHandler.handleBegin(context);
 
         // we only go through the element if we're not in a macro, or we are in a potentially new content
-        if (!withUnchangedContent) {
+        if (!withNonGeneratedContent) {
             // If we're on a span for unknown links then skip the event for its content.
             // Ex: <a href="..."><span class="wikicreatelinktext">...</span><span class="wikicreatelinkqm">?</span></a>
             WikiParameter classParam = params.getParameter("class");
@@ -84,9 +84,9 @@ public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiMode
     @Override
     protected void end(TagContext context)
     {
-        boolean unchangedContent = this.xWikiMacroHandler.handleEnd(context);
+        boolean nonGeneratedContent = this.xWikiMacroHandler.handleEnd(context);
 
-        if (!unchangedContent) {
+        if (!nonGeneratedContent) {
             WikiParameter classParam = context.getParams().getParameter("class");
             if (classParam != null) {
                 if (classParam.getValue().contains("wikigeneratedlinkcontent"))

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
@@ -20,6 +20,8 @@
 
 package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Common interface to all XWiki Tag Handler.
  *
@@ -67,17 +69,20 @@ public interface XWikiWikiModelHandler
      * Stack parameter which hold the instances of the MacroInfo encountered.
      * @since 10.10RC1
      */
+    @Unstable
     String MACRO_INFO = "macroInfo";
 
     /**
      * Stack parameters which records the syntax metadata encountered in the document.
      * @since 10.10RC1
      */
+    @Unstable
     String CURRENT_SYNTAX = "currentSyntax";
 
     /**
-     * Stack parameters which records if the previous div or span was triggered by an unchanged content metadata.
-     * @since 10.10RC1
+     * Stack parameters which records if the previous div or span was triggered by a non generated content metadata.
+     * @since 10.10
      */
-    String UNCHANGED_CONTENT_STACK = "unchangedContentStack";
+    @Unstable
+    String NON_GENERATED_CONTENT_STACK = "nonGeneratedContentStack";
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/macro/macro1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/macro/macro1.test
@@ -7,7 +7,7 @@
 <div>
 Some data to ignore
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container">
 <strong>New content</strong>
 </div>
 <div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/macro/macro2.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/macro/macro2.test
@@ -7,12 +7,12 @@
 <div>
 Some data to ignore
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-syntax="xhtml/1.0" class="xwiki-metadata-container">
 <!--startmacro:testcontentmacro|-||-|Old content-->
 <div>
 Some data to ignore 2
 </div>
-<div data-xwiki-unchanged-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container">
 <strong>New content</strong>
 </div>
 <div>

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
@@ -257,15 +257,15 @@ public abstract class AbstractMacro<P> implements Macro<P>, Initializable
     }
 
     /**
-     * Helper to get the proper metadata for unchanged content (i.e. content that has not gone through a
-     * Transformation).
+     * Helper to get the proper metadata for non generated content (i.e. content that has not gone through a
+     * Transformation). This content can be used for inline editing.
      *
      * @return the new metadata with the content type for the content represented as a string (e.g.
-     *         {@code java.util.List< org.xwiki.rendering.block.Block >} for content of type {@code Listw<Block>}
-     * @since 10.10RC1
+     *         {@code java.util.List< org.xwiki.rendering.block.Block >} for content of type {@code List<Block>}
+     * @since 10.10
      */
     @Unstable
-    protected MetaData getUnchangedContentMetaData()
+    protected MetaData getNonGeneratedContentMetaData()
     {
         MetaData metaData = new MetaData();
         Type contentType;
@@ -278,7 +278,7 @@ public abstract class AbstractMacro<P> implements Macro<P>, Initializable
 
         String converted = this.converterManager.convert(String.class, contentType);
 
-        metaData.addMetaData(MetaData.UNCHANGED_CONTENT, converted);
+        metaData.addMetaData(MetaData.NON_GENERATED_CONTENT, converted);
         return metaData;
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestInlineEditingMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestInlineEditingMacro.java
@@ -67,6 +67,6 @@ public class TestInlineEditingMacro extends AbstractNoParameterMacro
         }
 
         return Collections.singletonList(new MetaDataBlock(Collections.singletonList(contentBlock),
-            this.getUnchangedContentMetaData()));
+            this.getNonGeneratedContentMetaData()));
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestSyntaxWikiMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestSyntaxWikiMacro.java
@@ -57,7 +57,7 @@ public class TestSyntaxWikiMacro extends AbstractNoParameterMacro
         throws MacroExecutionException
     {
 
-        MetaData metaData = this.getUnchangedContentMetaData();
+        MetaData metaData = this.getNonGeneratedContentMetaData();
         metaData.addMetaData(MetaData.SYNTAX, "xwiki/2.0");
         return Collections.singletonList(new MetaDataBlock(Arrays.<Block>asList(new WordBlock(content)), metaData));
     }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
@@ -50,25 +50,25 @@ public class AbstractMacroTest
     private TestInlineEditingMacro macro2;
 
     @Test
-    public void getUnchangedMetadataDefault()
+    public void getNonGeneratedMetadataDefault()
     {
         assertNull(macro1.getDescriptor().getContentDescriptor());
-        MetaData unchangedContentMetaData = macro1.getUnchangedContentMetaData();
+        MetaData nonGeneratedContentMetaData = macro1.getNonGeneratedContentMetaData();
 
         MetaData expectedMetadata = new MetaData();
-        expectedMetadata.addMetaData(MetaData.UNCHANGED_CONTENT, "java.lang.String");
-        assertEquals(expectedMetadata, unchangedContentMetaData);
+        expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.lang.String");
+        assertEquals(expectedMetadata, nonGeneratedContentMetaData);
     }
 
     @Test
-    public void getUnchangedMetadataCustomDescriptor()
+    public void getNonGeneratedMetadataCustomDescriptor()
     {
         assertNotNull(macro2.getDescriptor().getContentDescriptor());
-        MetaData unchangedContentMetaData = macro2.getUnchangedContentMetaData();
+        MetaData nonGeneratedContentMetaData = macro2.getNonGeneratedContentMetaData();
 
         MetaData expectedMetadata = new MetaData();
-        expectedMetadata.addMetaData(MetaData.UNCHANGED_CONTENT, "java.util.List< org.xwiki.rendering.block.Block >");
-        assertEquals(expectedMetadata, unchangedContentMetaData);
+        expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.util.List< org.xwiki.rendering.block.Block >");
+        assertEquals(expectedMetadata, nonGeneratedContentMetaData);
     }
 
     @Test

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
@@ -126,7 +126,7 @@ public class MacroInfo
     }
 
     /**
-     * Allow to specify the content of the macro when changed in an unchanged content block.
+     * Allow to specify the content of the macro when changed in a non generated content block.
      *
      * @param content the new content of the macro.
      */


### PR DESCRIPTION
  * Use "non-generated-content" as a metadata name
  * Fix the associated variables and methods names
  * Fix the comments
  * Change the order of metadata in macro-content test, since the
alphabetical order changed between syntax and non-generated-content.