### PR TITLE
XRENDERING-535: Expose the groups property in parameter descriptors

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/pom.xml
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Rendering - Transformation - Macro</name>
   <description>XWiki Rendering - Transformation - Macro</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.77</xwiki.jacoco.instructionRatio>
     <xwiki.pitest.mutationThreshold>91</xwiki.pitest.mutationThreshold>
   </properties>
   <dependencies>

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
@@ -20,8 +20,11 @@
 package org.xwiki.rendering.macro.descriptor;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 import org.xwiki.properties.PropertyDescriptor;
+import org.xwiki.properties.PropertyGroupDescriptor;
 
 /**
  * The default implementation of {@link ParameterDescriptor}.
@@ -99,5 +102,15 @@ public class DefaultParameterDescriptor implements ParameterDescriptor
     public boolean isAdvanced()
     {
         return this.propertyDescriptor.isAdvanced();
+    }
+
+    @Override
+    public List<String> getGroup()
+    {
+        PropertyGroupDescriptor groupDescriptor = this.propertyDescriptor.getGroupDescriptor();
+        if (groupDescriptor != null) {
+            return groupDescriptor.getGroup();
+        }
+        return Collections.emptyList();
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
@@ -20,6 +20,8 @@
 package org.xwiki.rendering.macro.descriptor;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Define a macro parameter.
@@ -74,7 +76,8 @@ public interface ParameterDescriptor
      * @return indicate if the parameter is deprecated.
      * @since 10.10RC1
      */
-    default boolean isDeprecated() {
+    default boolean isDeprecated()
+    {
         return false;
     }
 
@@ -82,7 +85,17 @@ public interface ParameterDescriptor
      * @return indicate if the parameter is advanced.
      * @since 10.10RC1
      */
-    default boolean isAdvanced() {
+    default boolean isAdvanced()
+    {
         return false;
+    }
+
+    /**
+     * @return a hierarchy of groups.
+     * @since 10.11RC1
+     */
+    default List<String> getGroup()
+    {
+        return Collections.emptyList();
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/DefaultMacroDescriptorTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/DefaultMacroDescriptorTest.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rendering.macro.descriptor;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -27,6 +29,7 @@ import org.junit.Test;
 import org.xwiki.properties.BeanManager;
 import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyGroup;
 import org.xwiki.properties.annotation.PropertyHidden;
 import org.xwiki.properties.annotation.PropertyMandatory;
 import org.xwiki.rendering.macro.MacroId;
@@ -136,6 +139,7 @@ public class DefaultMacroDescriptorTest extends AbstractComponentTestCase
         }
 
         @PropertyAdvanced
+        @PropertyGroup({"parentGroup", "childGroup"})
         public String getAdvancedParameter()
         {
             return advancedParameter;
@@ -184,9 +188,11 @@ public class DefaultMacroDescriptorTest extends AbstractComponentTestCase
 
         ParameterDescriptor deprecatedDescriptor = map.get("deprecatedparameter");
         Assert.assertTrue(deprecatedDescriptor.isDeprecated());
+        Assert.assertEquals(Collections.emptyList(), deprecatedDescriptor.getGroup());
 
         ParameterDescriptor advancedDescriptor = map.get("advancedparameter");
         Assert.assertTrue(advancedDescriptor.isAdvanced());
+        Assert.assertEquals(Arrays.asList("parentGroup", "childGroup"), advancedDescriptor.getGroup());
     }
 
     @Test
@@ -243,5 +249,18 @@ public class DefaultMacroDescriptorTest extends AbstractComponentTestCase
         Assert.assertEquals("param3 description", param3Descriptor.getDescription());
         Assert.assertSame(boolean.class, param3Descriptor.getParameterType());
         Assert.assertEquals(true, param3Descriptor.isMandatory());
+    }
+
+    @Test
+    public void testLegacyParameterDescriptor()
+    {
+        Map<String, ParameterDescriptor> map = this.macroDescriptor.getParameterDescriptorMap();
+
+        ParameterDescriptor deprecatedDescriptor = new LegacyParameterDescriptor(map.get("deprecatedparameter"));
+        Assert.assertFalse(deprecatedDescriptor.isDeprecated());
+
+        ParameterDescriptor advancedDescriptor = new LegacyParameterDescriptor(map.get("advancedparameter"));
+        Assert.assertFalse(advancedDescriptor.isAdvanced());
+        Assert.assertEquals(Collections.emptyList(), advancedDescriptor.getGroup());
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/LegacyParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/LegacyParameterDescriptor.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.macro.descriptor;
+
+import java.lang.reflect.Type;
+
+/**
+ * Legacy implementation of {@link ParameterDescriptor}.
+ */
+public class LegacyParameterDescriptor implements ParameterDescriptor
+{
+    private ParameterDescriptor parameterDescriptor;
+    /**
+     * Creates a new {@link LegacyParameterDescriptor} instance using the given {@link ParameterDescriptor}.
+     *
+     * @param parameterDescriptor Parameter descriptor on which methods are called
+     */
+    public LegacyParameterDescriptor(ParameterDescriptor parameterDescriptor)
+    {
+        this.parameterDescriptor = parameterDescriptor;
+    }
+
+    @Override
+    public String getId()
+    {
+        return this.parameterDescriptor.getId();
+    }
+
+    @Override
+    public String getName()
+    {
+        return this.parameterDescriptor.getName();
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return this.parameterDescriptor.getDescription();
+    }
+
+    @Override
+    @Deprecated
+    public Class<?> getType()
+    {
+        return this.parameterDescriptor.getType();
+    }
+
+    @Override
+    public Type getParameterType()
+    {
+        return this.parameterDescriptor.getParameterType();
+    }
+
+    @Override
+    public Object getDefaultValue()
+    {
+        return this.parameterDescriptor.getDefaultValue();
+    }
+
+    @Override
+    public boolean isMandatory()
+    {
+        return this.parameterDescriptor.isMandatory();
+    }
+}


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XRENDERING-535

### Changes

* Expose the group property.
* Add tests.
* Create a LegacyParameterDescriptor to test default interface methods.
* Increase the jacoco threshold.