### PR TITLE
XWIKI-15914: Cannot add Attachment Selector Macro into a page

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro27.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro27.test
@@ -1,0 +1,9 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test that we handle when too many stop macro are provided
+.#-----------------------------------------------------
+<!--startmacro:attachmentSelector|-|--><!--stopmacro--><!--stopmacro--><!--stopmacro-->
+.#-----------------------------------------------------
+.expect|annotatedxhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:attachmentSelector|-|--><!--stopmacro-->

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
@@ -150,18 +150,20 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
 
     private void handleMacroCommentStop(TagStack stack)
     {
-        MacroInfo macroInfo = (MacroInfo) stack.popStackParameter(MACRO_INFO);
-        IgnoreElementRule ignoreElementRule = stack.popIgnoreElementRule();
+        if (stack.getStackParameter(MACRO_INFO) != null) {
+            MacroInfo macroInfo = (MacroInfo) stack.popStackParameter(MACRO_INFO);
+            IgnoreElementRule ignoreElementRule = stack.popIgnoreElementRule();
 
-        // if we were ignoring all we don't want to output the macro
-        if (!ignoreElementRule.equals(IGNORE_ALL)) {
-            if (stack.isInsideBlockElement()) {
-                stack.getScannerContext().onMacroInline(macroInfo.getName(), macroInfo.getParameters(),
-                    macroInfo.getContent());
-            } else {
-                TagHandler.sendEmptyLines(stack);
-                stack.getScannerContext().onMacroBlock(macroInfo.getName(), macroInfo.getParameters(),
-                    macroInfo.getContent());
+            // if we were ignoring all we don't want to output the macro
+            if (!ignoreElementRule.equals(IGNORE_ALL)) {
+                if (stack.isInsideBlockElement()) {
+                    stack.getScannerContext().onMacroInline(macroInfo.getName(), macroInfo.getParameters(),
+                        macroInfo.getContent());
+                } else {
+                    TagHandler.sendEmptyLines(stack);
+                    stack.getScannerContext().onMacroBlock(macroInfo.getName(), macroInfo.getParameters(),
+                        macroInfo.getContent());
+                }
             }
         }
     }


### PR DESCRIPTION
  * Protect XWikiCommentHandler#handleMacroCommentStop in case no macro
info is available in the context