### PR TITLE
XRENDERING-553: Expose the display type property in the parameter descriptors

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
@@ -107,4 +107,10 @@ public class DefaultParameterDescriptor implements ParameterDescriptor
     {
         return this.propertyDescriptor.getGroupDescriptor();
     }
+
+    @Override
+    public Type getDisplayType()
+    {
+        return this.propertyDescriptor.getDisplayType();
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
@@ -98,4 +98,13 @@ public interface ParameterDescriptor
     {
         return null;
     }
+
+    /**
+     * @return the type used to display the property.
+     * @since 11.0
+     */
+    default Type getDisplayType()
+    {
+        return getParameterType();
+    }
 }


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XCOMMONS-1558

### Change

* Add the display type in the parameter descriptor.

### Note

See https://github.com/xwiki/xwiki-commons/pull/64.