### PR TITLE
XRENDERING-556: Allow to parse inline editable macro parameters in html result

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/MetaData.java
@@ -68,6 +68,14 @@ public class MetaData
     public static final String NON_GENERATED_CONTENT = "non-generated-content";
 
     /**
+     * Represents a metadata attached to a specific parameter identified by the given name.
+     *
+     * @since 11.1RC1
+     */
+    @Unstable
+    public static final String PARAMETER_NAME = "parameter-name";
+
+    /**
      * Contains all MetaData for this Block and its children. Note: we preserve the order of metadata elements as they
      * are added as a service for the user so he can count on it.
      */

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro28.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro28.test
@@ -1,0 +1,13 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.# Test a macro that have inline editable content and parameter.
+.#-----------------------------------------------------
+{{box title="mytitle"}}
+Some content
+{{/box}}
+
+.#-----------------------------------------------------
+.expect|annotatedxhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:box|-|title="mytitle"|-|Some content--><div class="box"><div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">mytitle</div><div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"><p>Some content</p></div></div><!--stopmacro-->

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro29.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro29.test
@@ -1,0 +1,18 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test parsing of a macro parameter and some content.
+.#-----------------------------------------------------
+<!--startmacro:box|-|title="old title"|-|Old content-->
+<div class="box">
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">mytitle</div>
+<div data-xwiki-non-generated-content="java.util.List&lt; org.xwiki.rendering.block.Block &gt;" class="xwiki-metadata-container"><p>Some content</p></div>
+</div>
+<!--stopmacro-->
+
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{box title="mytitle"}}
+Some content
+{{/box}}

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/pom.xml
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/pom.xml
@@ -36,4 +36,29 @@
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Box Macro</xwiki.extension.name>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <analysisConfiguration><![CDATA[
+            {
+              "revapi": {
+                "ignore" : [
+                  {
+                    "code": "java.annotation.added",
+                    "old": "method void org.xwiki.rendering.macro.box.BoxMacroParameters::setTitle(java.lang.String)",
+                    "new": "method void org.xwiki.rendering.macro.box.BoxMacroParameters::setTitle(java.lang.String)",
+                    "annotation": "@org.xwiki.properties.annotation.PropertyDisplayType({java.util.List.class, org.xwiki.rendering.block.Block.class})",
+                    "justification": "This allows inline editing on box macro title."
+                  },
+                ]
+              }
+            }
+        ]]></analysisConfiguration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/AbstractBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/AbstractBoxMacro.java
@@ -32,6 +32,7 @@ import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.FormatBlock;
 import org.xwiki.rendering.block.GroupBlock;
 import org.xwiki.rendering.block.ImageBlock;
+import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.NewLineBlock;
 import org.xwiki.rendering.listener.Format;
 import org.xwiki.rendering.listener.reference.ResourceReference;
@@ -277,8 +278,12 @@ public abstract class AbstractBoxMacro<P extends BoxMacroParameters> extends Abs
                 // we add the title, if there is one
                 if (!StringUtils.isEmpty(titleParameter)) {
                     // Don't execute transformations explicitly. They'll be executed on the generated content later on.
-                    ret.addChildren(AbstractBoxMacro.this.contentParser.parse(
-                        titleParameter, context, false, true).getChildren());
+                    List<? extends Block> titleBlock = AbstractBoxMacro.this.contentParser.parse(
+                        titleParameter, context, false, true).getChildren();
+
+                    // put the right metadata around it
+                    ret.addChildren(Collections.singletonList(new MetaDataBlock(titleBlock,
+                        AbstractBoxMacro.this.getNonGeneratedContentMetaData("title"))));
                 }
                 if (titleBlockList != null) {
                     ret.addChildren(titleBlockList);

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/BoxMacroParameters.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/BoxMacroParameters.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyHidden;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.listener.reference.ResourceReference;
@@ -91,6 +92,7 @@ public class BoxMacroParameters
      * @param title refer to {@link #getTitle()}
      */
     @PropertyDescription("the title which is to be displayed in the message box")
+    @PropertyDisplayType({ List.class, Block.class })
     public void setTitle(String title)
     {
         this.title = title;

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox5.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox5.test
@@ -11,9 +11,11 @@ beginMacroMarkerStandalone [box] [title=[[XWiki>>http://www.xwiki.org]]|cssClass
 beginGroup [[class]=[box myCLASS]]
 onImage [Typed = [false] Type = [url] Reference = [http://l.yimg.com/i/i/fr/tr/usa4.jpg]] [true]
 onNewLine
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][parameter-name]=[title]]
 beginLink [Typed = [false] Type = [url] Reference = [http://www.xwiki.org]] [false]
 onWord [XWiki]
 endLink [Typed = [false] Type = [url] Reference = [http://www.xwiki.org]] [false]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][parameter-name]=[title]]
 beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 beginParagraph
 onWord [alabala]

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox8.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox8.test
@@ -10,7 +10,9 @@
 beginDocument
 beginMacroMarkerStandalone [custombox] [] [something]
 beginGroup [[class]=[box]]
+beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][parameter-name]=[title]]
 onWord [something]
+endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >][parameter-name]=[title]]
 beginMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endMetaData [[non-generated-content]=[java.util.List< org.xwiki.rendering.block.Block >]]
 endGroup [[class]=[box]]

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
@@ -20,8 +20,6 @@
 
 package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
-import org.xwiki.stability.Unstable;
-
 /**
  * Common interface to all XWiki Tag Handler.
  *

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
@@ -85,4 +85,11 @@ public interface XWikiWikiModelHandler
      */
     @Unstable
     String NON_GENERATED_CONTENT_STACK = "nonGeneratedContentStack";
+
+    /**
+     * Stack parameter which record the name of the parameter the current content is dedicated to.
+     * @since 11.1RC1
+     */
+    @Unstable
+    String PARAMETER_CONTENT_NAME = "parameterContentName";
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiModelHandler.java
@@ -69,27 +69,23 @@ public interface XWikiWikiModelHandler
      * Stack parameter which hold the instances of the MacroInfo encountered.
      * @since 10.10RC1
      */
-    @Unstable
     String MACRO_INFO = "macroInfo";
 
     /**
      * Stack parameters which records the syntax metadata encountered in the document.
      * @since 10.10RC1
      */
-    @Unstable
     String CURRENT_SYNTAX = "currentSyntax";
 
     /**
      * Stack parameters which records if the previous div or span was triggered by a non generated content metadata.
      * @since 10.10
      */
-    @Unstable
     String NON_GENERATED_CONTENT_STACK = "nonGeneratedContentStack";
 
     /**
      * Stack parameter which record the name of the parameter the current content is dedicated to.
      * @since 11.1RC1
      */
-    @Unstable
     String PARAMETER_CONTENT_NAME = "parameterContentName";
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
@@ -281,4 +281,32 @@ public abstract class AbstractMacro<P> implements Macro<P>, Initializable
         metaData.addMetaData(MetaData.NON_GENERATED_CONTENT, converted);
         return metaData;
     }
+
+    /**
+     * Helper to get the proper metadata for non generated content (i.e. content that has not gone through a
+     * Transformation) for a specific parameter. This content can be used for inline editing.
+     *
+     * @param parameterName the name of the parameter as defined in the macro
+     * @return the new metadata with the content type for the content represented as a string (e.g.
+     *         {@code java.util.List< org.xwiki.rendering.block.Block >} for content of type {@code List<Block>}
+     * @since 11.1RC1
+     */
+    @Unstable
+    protected MetaData getNonGeneratedContentMetaData(String parameterName)
+    {
+        MetaData metaData = new MetaData();
+        Type contentType;
+
+        if (this.contentDescriptor != null) {
+            contentType = this.contentDescriptor.getType();
+        } else {
+            contentType = DefaultContentDescriptor.DEFAULT_CONTENT_TYPE;
+        }
+
+        String converted = this.converterManager.convert(String.class, contentType);
+
+        metaData.addMetaData(MetaData.NON_GENERATED_CONTENT, converted);
+        metaData.addMetaData(MetaData.PARAMETER_NAME, parameterName);
+        return metaData;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/AbstractMacro.java
@@ -33,6 +33,7 @@ import org.xwiki.rendering.macro.descriptor.AbstractMacroDescriptor;
 import org.xwiki.rendering.macro.descriptor.ContentDescriptor;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.descriptor.DefaultMacroDescriptor;
+import org.xwiki.rendering.macro.descriptor.DefaultParameterDescriptor;
 import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
 import org.xwiki.stability.Unstable;
 
@@ -297,10 +298,12 @@ public abstract class AbstractMacro<P> implements Macro<P>, Initializable
         MetaData metaData = new MetaData();
         Type contentType;
 
-        if (this.contentDescriptor != null) {
-            contentType = this.contentDescriptor.getType();
+        if (this.macroDescriptor != null
+            && this.macroDescriptor.getParameterDescriptorMap() != null
+            && this.macroDescriptor.getParameterDescriptorMap().containsKey(parameterName)) {
+            contentType = this.macroDescriptor.getParameterDescriptorMap().get(parameterName).getDisplayType();
         } else {
-            contentType = DefaultContentDescriptor.DEFAULT_CONTENT_TYPE;
+            contentType = DefaultParameterDescriptor.DEFAULT_PARAMETER_TYPE;
         }
 
         String converted = this.converterManager.convert(String.class, contentType);

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
@@ -33,6 +33,13 @@ import org.xwiki.properties.PropertyGroupDescriptor;
 public class DefaultParameterDescriptor implements ParameterDescriptor
 {
     /**
+     * Default content type of all content descriptors.
+     *
+     * @since 11.1RC1
+     */
+    public static final Type DEFAULT_PARAMETER_TYPE = String.class;
+
+    /**
      * The description of the parameter.
      */
     private PropertyDescriptor propertyDescriptor;

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestInlineEditingMacroParameter.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestInlineEditingMacroParameter.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.rendering.internal.transformation.macro;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Named;
@@ -27,47 +26,30 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.block.Block;
-import org.xwiki.rendering.block.MetaDataBlock;
-import org.xwiki.rendering.block.ParagraphBlock;
-import org.xwiki.rendering.block.WordBlock;
 import org.xwiki.rendering.macro.AbstractMacro;
-import org.xwiki.rendering.macro.AbstractNoParameterMacro;
 import org.xwiki.rendering.macro.MacroExecutionException;
-import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 
-import static org.xwiki.rendering.block.Block.LIST_BLOCK_TYPE;
-
 @Component
-@Named("testinlineeditingmacro")
+@Named("testinlineeditingmacroparameter")
 @Singleton
-public class TestInlineEditingMacro extends AbstractNoParameterMacro
+public class TestInlineEditingMacroParameter extends AbstractMacro<TestMacroParameter>
 {
-    public TestInlineEditingMacro()
+    public TestInlineEditingMacroParameter()
     {
-        super("Macro Inline Editing", "", new DefaultContentDescriptor("content", true, LIST_BLOCK_TYPE));
+        super("Macro parameter inline editing", "", TestMacroParameter.class);
     }
 
     @Override
     public boolean supportsInlineMode()
     {
-        return true;
+        return false;
     }
 
     @Override
-    public List<Block> execute(Object parameters, String content, MacroTransformationContext context)
+    public List<Block> execute(TestMacroParameter parameters, String content, MacroTransformationContext context)
         throws MacroExecutionException
     {
-        Block contentBlock;
-
-        WordBlock wordBlock = new WordBlock(content);
-        if (context.isInline()) {
-            contentBlock = wordBlock;
-        } else {
-            contentBlock = new ParagraphBlock(Collections.singletonList(wordBlock));
-        }
-
-        return Collections.singletonList(new MetaDataBlock(Collections.singletonList(contentBlock),
-            this.getNonGeneratedContentMetaData()));
+        return null;
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestMacroParameter.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestMacroParameter.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.transformation.macro;
+
+import java.util.List;
+
+import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyDisplayType;
+import org.xwiki.rendering.block.Block;
+
+public class TestMacroParameter
+{
+    private String param1;
+    private String param2;
+
+    public String getParam1()
+    {
+        return param1;
+    }
+
+    @PropertyDescription("Param1")
+    @PropertyDisplayType({ List.class, Block.class })
+    public void setParam1(String param1)
+    {
+        this.param1 = param1;
+    }
+
+    public String getParam2()
+    {
+        return param2;
+    }
+
+    @PropertyDescription("Param2")
+    public void setParam2(String param2)
+    {
+        this.param2 = param2;
+    }
+}

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
@@ -21,6 +21,7 @@ package org.xwiki.rendering.macro;
 
 import org.junit.jupiter.api.Test;
 import org.xwiki.rendering.internal.transformation.macro.TestInlineEditingMacro;
+import org.xwiki.rendering.internal.transformation.macro.TestInlineEditingMacroParameter;
 import org.xwiki.rendering.internal.transformation.macro.TestSimpleMacro;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.test.annotation.AllComponents;
@@ -49,6 +50,9 @@ public class AbstractMacroTest
     @InjectMockComponents
     private TestInlineEditingMacro macro2;
 
+    @InjectMockComponents
+    private TestInlineEditingMacroParameter macro3;
+
     @Test
     public void getNonGeneratedMetadataDefault()
     {
@@ -74,12 +78,25 @@ public class AbstractMacroTest
     @Test
     public void getNonGeneratedMetadataForParameterCustomDescriptor()
     {
-        assertNotNull(macro2.getDescriptor().getContentDescriptor());
-        MetaData nonGeneratedContentMetaData = macro2.getNonGeneratedContentMetaData("param1");
+        MetaData nonGeneratedContentMetaData = macro3.getNonGeneratedContentMetaData("param1");
 
         MetaData expectedMetadata = new MetaData();
         expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.util.List< org.xwiki.rendering.block.Block >");
         expectedMetadata.addMetaData(MetaData.PARAMETER_NAME, "param1");
+        assertEquals(expectedMetadata, nonGeneratedContentMetaData);
+
+        nonGeneratedContentMetaData = macro3.getNonGeneratedContentMetaData("param2");
+
+        expectedMetadata = new MetaData();
+        expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.lang.String");
+        expectedMetadata.addMetaData(MetaData.PARAMETER_NAME, "param2");
+        assertEquals(expectedMetadata, nonGeneratedContentMetaData);
+
+        nonGeneratedContentMetaData = macro3.getNonGeneratedContentMetaData("param3");
+
+        expectedMetadata = new MetaData();
+        expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.lang.String");
+        expectedMetadata.addMetaData(MetaData.PARAMETER_NAME, "param3");
         assertEquals(expectedMetadata, nonGeneratedContentMetaData);
     }
 

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/macro/AbstractMacroTest.java
@@ -72,6 +72,18 @@ public class AbstractMacroTest
     }
 
     @Test
+    public void getNonGeneratedMetadataForParameterCustomDescriptor()
+    {
+        assertNotNull(macro2.getDescriptor().getContentDescriptor());
+        MetaData nonGeneratedContentMetaData = macro2.getNonGeneratedContentMetaData("param1");
+
+        MetaData expectedMetadata = new MetaData();
+        expectedMetadata.addMetaData(MetaData.NON_GENERATED_CONTENT, "java.util.List< org.xwiki.rendering.block.Block >");
+        expectedMetadata.addMetaData(MetaData.PARAMETER_NAME, "param1");
+        assertEquals(expectedMetadata, nonGeneratedContentMetaData);
+    }
+
+    @Test
     public void supportsInlineMode()
     {
         assertFalse(macro1.supportsInlineMode());

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
@@ -49,7 +49,7 @@ public class MacroInfo
     private static final String MACRO_SEPARATOR = "|-|";
 
     private final String name;
-    private final WikiParameters parameters;
+    private WikiParameters parameters;
 
     private String content;
 
@@ -115,6 +115,17 @@ public class MacroInfo
     public WikiParameters getParameters()
     {
         return parameters;
+    }
+
+    /**
+     * Allow to set new parameters for this macro.
+     * @param parameters the parameters to set.
+     * @since 11.1RC1
+     */
+    @Unstable
+    public void setParameters(WikiParameters parameters)
+    {
+        this.parameters = parameters;
     }
 
     /**


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XRENDERING-556

## Solution

  * Define a new metadata attribute for identifying parameter
  * Define an utility method in AbstractMacro to create a non generated
metadata for a specific parameter
  * Specify that the title block is non generated in BoxMacro
  * Add new tests for both rendering and parsing of BoxMacro
  * Handle the new metadata attribute when setting the content in
XWikiMacroHandler
  * Upgrade Macro Box tests

## Test

![peek 06-02-2019 17-13](https://user-images.githubusercontent.com/1478232/52355432-9bac4300-2a32-11e9-9535-6a9c9384a306.gif)
