### PR TITLE
XRENDERING-562: Support of redundant non-generated content div

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,18 @@
                     }
                 },
                 "ignore" : [
-                  // Add more ignores below...
+                  {
+                    "code": "java.method.parameterTypeParameterChanged",
+                    "old": "parameter void org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule::<init>(===java.util.function.Predicate<org.xwiki.rendering.wikimodel.xhtml.impl.TagContext>===, boolean)",
+                    "new": "parameter void org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule::<init>(===java.util.function.Predicate<org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule>===, boolean)",
+                    "justification": "Change the predicate to use directly the current object. The IgnoreElementRule class is still an unstable API"
+                  },
+                  {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method void org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule::switchRule(org.xwiki.rendering.wikimodel.xhtml.impl.TagContext)",
+                    "new": "method void org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule::switchRule(org.xwiki.rendering.wikimodel.xhtml.impl.TagContext, boolean)",
+                    "justification": "Call the switch method with the info if it is from a begin or an end element. The IgnoreElementRule class is still an Unstable API."
+                  },
                 ]
               }
             }

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro30.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro30.test
@@ -1,0 +1,26 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test parsing of a macro content with two data-non-generated divs.
+.#-----------------------------------------------------
+<!--startmacro:box|-|Old content-->
+<div class="box">
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container">
+<p>Some content</p>
+</div>
+</div>
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">
+mytitle
+</div>
+</div>
+</div>
+<!--stopmacro-->
+
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{box title="mytitle"}}
+Some content
+{{/box}}

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro31.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro31.test
@@ -1,0 +1,21 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test parsing of a macro with multiple content and parameter div only take into account the last ones.
+.#-----------------------------------------------------
+<!--startmacro:box|-|title="old title"|-|Old content-->
+<div class="box">
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">title1</div>
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p>Some content1</p></div>
+
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" data-xwiki-parameter-name="title" class="xwiki-metadata-container">title2</div>
+<div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p>Some content2</p></div>
+</div>
+<!--stopmacro-->
+
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{box title="title2"}}
+Some content2
+{{/box}}

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/IgnoreElementRule.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/IgnoreElementRule.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rendering.wikimodel.xhtml.impl;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.xwiki.stability.Unstable;
@@ -36,17 +38,24 @@ public class IgnoreElementRule
 {
     private boolean isActive;
 
-    private Predicate<TagContext> activateWhen;
+    private TagContext tagContext;
+
+    private boolean isBeginElement;
+
+    private Map<String, Object> ruleContext;
+
+    private Predicate<IgnoreElementRule> switchWhen;
 
     /**
      * Default constructor for an IgnoreElementRule.
      * @param tagContextPredicate the predicate used to switch the active flag.
      * @param isActive the default flag to set the rule as active or not.
      */
-    public IgnoreElementRule(Predicate<TagContext> tagContextPredicate, boolean isActive)
+    public IgnoreElementRule(Predicate<IgnoreElementRule> tagContextPredicate, boolean isActive)
     {
-        this.activateWhen = tagContextPredicate;
+        this.switchWhen = tagContextPredicate;
         this.isActive = isActive;
+        this.ruleContext = new HashMap<>();
     }
 
     /**
@@ -58,12 +67,46 @@ public class IgnoreElementRule
     }
 
     /**
+     * @return the tag context that is used for switching rule.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public TagContext getTagContext()
+    {
+        return tagContext;
+    }
+
+    /**
+     * @return true if we are in a begin element. This can be used inside the predicate to activate the rule.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public boolean isBeginElement()
+    {
+        return isBeginElement;
+    }
+
+    /**
+     * @return a mutable rule context to allow get/set information that could be used for the predicate.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public Map<String, Object> getRuleContext()
+    {
+        return ruleContext;
+    }
+
+    /**
      * Switch the active value (see {@link #isActive()} if the predicate of the rule match the given tagContext.
      * @param tagContext The tag context which can match the predicate.
+     * @param begin true indicates that it's the begin tag which called the predicate
      */
-    public void switchRule(TagContext tagContext)
+    public void switchRule(TagContext tagContext, boolean begin)
     {
-        if (this.activateWhen.test(tagContext)) {
+        this.tagContext = tagContext;
+        this.isBeginElement = begin;
+
+        if (this.switchWhen.test(this)) {
             this.isActive = !this.isActive;
         }
     }

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/MacroInfo.java
@@ -20,10 +20,13 @@
 package org.xwiki.rendering.wikimodel.xhtml.impl;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.WikiParameters;
+import org.xwiki.rendering.wikimodel.impl.WikiScannerContext;
 import org.xwiki.rendering.wikimodel.impl.WikiScannerUtil;
 import org.xwiki.stability.Unstable;
 
@@ -52,6 +55,10 @@ public class MacroInfo
     private WikiParameters parameters;
 
     private String content;
+
+    private WikiScannerContext contentScannerContext;
+
+    private Map<String, WikiScannerContext> parameterScannerContextMap;
 
     /**
      * Build a MacroInfo based on the content of a comment.
@@ -99,6 +106,8 @@ public class MacroInfo
             this.content = null;
             parameters = WikiParameters.EMPTY;
         }
+
+        this.parameterScannerContextMap = new HashMap<>();
     }
 
     /**
@@ -144,5 +153,47 @@ public class MacroInfo
     public void setContent(String content)
     {
         this.content = content;
+    }
+
+    /**
+     * @return the scanner context that is used to parse the content of the macro.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public WikiScannerContext getContentScannerContext()
+    {
+        return contentScannerContext;
+    }
+
+    /**
+     * @param contentScannerContext the scanner context that is used to parse the content of the macro.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public void setContentScannerContext(WikiScannerContext contentScannerContext)
+    {
+        this.contentScannerContext = contentScannerContext;
+    }
+
+    /**
+     * @param parameter a parameter name of the macro
+     * @param scannerContext the scanner context that is used to parse the specified parameter of the macro.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public void setParameterScannerContext(String parameter, WikiScannerContext scannerContext)
+    {
+        this.parameterScannerContextMap.put(parameter, scannerContext);
+    }
+
+    /**
+     * @param parameter a parameter name of the macro
+     * @return the scanner context that is used to parse the specified parameter of the macro.
+     * @since 11.4RC1
+     */
+    @Unstable
+    public WikiScannerContext getParameterScannerContext(String parameter)
+    {
+        return this.parameterScannerContextMap.get(parameter);
     }
 }

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagStack.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagStack.java
@@ -105,7 +105,7 @@ public class TagStack
         TagHandler handler = fMap.get(name);
 
         // check if the ignore rule should be activated
-        this.switchIgnoreRule(fPeek);
+        this.switchIgnoreRule(fPeek, true);
         if (!this.shouldIgnoreElements()) {
             if (!(handler instanceof AbstractFormatTagHandler)) {
                 fPreviousCharType = null;
@@ -124,7 +124,7 @@ public class TagStack
         }
 
         // check if the ignore rule should be deactivated
-        this.switchIgnoreRule(fPeek);
+        this.switchIgnoreRule(fPeek, false);
         fPeek = fPeek.getParentContext();
     }
 
@@ -479,13 +479,14 @@ public class TagStack
      * Check if an ignore rule should be (de)activated based on the given tag context.
      *
      * @param fPeek the tag context to match with a rule for activating it.
+     * @param begin if true, then the method is called with a begin element.
      *
      * @since 10.10RC1
      */
-    private void switchIgnoreRule(TagContext fPeek)
+    private void switchIgnoreRule(TagContext fPeek, boolean begin)
     {
         if (!this.fignoreElementRuleStack.isEmpty()) {
-            this.fignoreElementRuleStack.peek().switchRule(fPeek);
+            this.fignoreElementRuleStack.peek().switchRule(fPeek, begin);
         }
     }
 }


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XRENDERING-562

## Solution

The proposed solution is twofolds:
  1. I needed to avoid switching the IgnoreElementRule each time a non-generated content div is found, but to use the state of the rule itself. I had to change its API for that but I guess it's ok since it was unstable. 

  2. I also needed to ensure that only one scanner is created for the content of the macro, to avoid to reset its content to an empty value when going into the second closing non-generated div.