### PR TITLE
XRENDERING-141: Docbook parser fails to support Italic syntax nested inside Bold syntax

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-docbook/src/test/resources/docbook44/config.properties
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-docbook/src/test/resources/docbook44/config.properties
@@ -24,8 +24,5 @@
 # http://www.docbook.org/tdg/en/html/literallayout-x.html
 notApplicableTests = .*monospace.*
 
-# See http://jira.xwiki.org/jira/browse/XRENDERING-141
-failingTests = .*bold3.*
-
 # Cannot have standalone verbatim, it's considered inline wrongly...
 failingTests = .*verbatim2.*


### PR DESCRIPTION
Removing the failingTests filter since it does not fails anymore.