### PR TITLE
XRENDERING-592: Unsafe production of XMLReader objects

### DIFF
--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/XhtmlParser.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/XhtmlParser.java
@@ -27,6 +27,8 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xwiki.rendering.wikimodel.IWemListener;
@@ -143,6 +145,11 @@ public class XhtmlParser implements IWikiParser
             reader = fXmlReader;
         } else {
             SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            try {
+                parserFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                // On ParserConfigurationException, we throw it.
+            }
             SAXParser parser = parserFactory.newSAXParser();
             XMLReader xmlReader = parser.getXMLReader();
 

--- a/xwiki-rendering-xml/src/main/java/org/xwiki/rendering/xml/internal/parser/AbstractStreamParser.java
+++ b/xwiki-rendering-xml/src/main/java/org/xwiki/rendering/xml/internal/parser/AbstractStreamParser.java
@@ -29,6 +29,8 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
@@ -39,6 +41,7 @@ import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.parser.StreamParser;
 import org.xwiki.rendering.parser.xml.ContentHandlerStreamParser;
 import org.xwiki.rendering.parser.xml.ContentHandlerStreamParserFactory;
+import org.xwiki.xml.internal.LocalEntityResolver;
 
 /**
  * Base class for XML based syntax stream parsers.
@@ -63,6 +66,14 @@ public abstract class AbstractStreamParser implements ContentHandlerStreamParser
     public void initialize() throws InitializationException
     {
         this.parserFactory = SAXParserFactory.newInstance();
+        try {
+            this.parserFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            // A really old parser is being used?
+        } catch (ParserConfigurationException e) {
+            // Not good, better throw it.
+            throw new InitializationException("Error configuring SAXParserFactory.", e);
+        }
     }
 
     @Override
@@ -103,6 +114,9 @@ public abstract class AbstractStreamParser implements ContentHandlerStreamParser
     {
         SAXParser saxParser = this.parserFactory.newSAXParser();
         XMLReader xmlReader = saxParser.getXMLReader();
+
+        // Set an EntityResolver so DTDs can be found.
+        xmlReader.setEntityResolver(new LocalEntityResolver());
 
         ContentHandlerStreamParser parser = createParser(listener);
         xmlReader.setContentHandler(parser);


### PR DESCRIPTION
Sets the `FEATURE_SECURE_PROCESSING` feature in the `SAXParserFactory`. One of the classes could be modified to retrieve the `XMLReader` from `ComponentManager` instead, but I'm not sure of the possible side-effects of that.

It also sets an `EntityResolver` so DTDs can be found (the `XMLReader` no longer retrieves everything). Breakages arising from this change could be possible, if a processed document is using an unsafe `DOCTYPE` declaration.