### PR TITLE
[MISC] Move XHTMLChainingRenderer#HTML_TYPES to SyntaxType to avoid forgetting syntaxes from the HTML group

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
@@ -126,9 +126,11 @@ public class SyntaxType implements Comparable<SyntaxType>
     public static final SyntaxType HTML = register("html", "HTML");
 
     /**
-     * All HTML types.
+     * Browser specific syntaxes.
+     *
+     * @since 13.9RC1
      */
-    public static final Set<SyntaxType> HTML_TYPES = SetUtils.hashSet(XHTML, HTML, ANNOTATED_XHTML, ANNOTATED_HTML);
+    public static final Set<SyntaxType> BROWSER_TYPES = SetUtils.hashSet(XHTML, HTML, ANNOTATED_XHTML, ANNOTATED_HTML);
 
     /**
      * Plain text syntax.

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
@@ -126,7 +126,7 @@ public class SyntaxType implements Comparable<SyntaxType>
     public static final SyntaxType HTML = register("html", "HTML");
 
     /**
-     * Browser specific syntaxes.
+     * Syntaxes that can be rendered directly by Browsers.
      *
      * @since 13.9RC1
      */

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
@@ -25,7 +25,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -122,6 +124,11 @@ public class SyntaxType implements Comparable<SyntaxType>
      * HTML syntaxes.
      */
     public static final SyntaxType HTML = register("html", "HTML");
+
+    /**
+     * All HTML types.
+     */
+    public static final Set<SyntaxType> HTML_TYPES = SetUtils.hashSet(XHTML, HTML, ANNOTATED_XHTML, ANNOTATED_HTML);
 
     /**
      * Plain text syntax.

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/syntax/SyntaxType.java
@@ -126,11 +126,12 @@ public class SyntaxType implements Comparable<SyntaxType>
     public static final SyntaxType HTML = register("html", "HTML");
 
     /**
-     * Syntaxes that can be rendered directly by Browsers.
+     * Syntaxes that are from the HTML family.
      *
      * @since 13.9RC1
      */
-    public static final Set<SyntaxType> BROWSER_TYPES = SetUtils.hashSet(XHTML, HTML, ANNOTATED_XHTML, ANNOTATED_HTML);
+    public static final Set<SyntaxType> HTML_FAMILY_TYPES = SetUtils.hashSet(XHTML, HTML, ANNOTATED_XHTML,
+			ANNOTATED_HTML);
 
     /**
      * Plain text syntax.

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
@@ -22,9 +22,7 @@ package org.xwiki.rendering.internal.renderer.xhtml;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import org.apache.commons.collections4.SetUtils;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.listener.Format;
@@ -61,9 +59,6 @@ public class XHTMLChainingRenderer extends AbstractChainingPrintRenderer
      * who specified an id.
      */
     public static final String GENERATEDIDCLASS = "wikigeneratedid";
-
-    private static final Set<SyntaxType> HTML_TYPES =
-        SetUtils.hashSet(SyntaxType.XHTML, SyntaxType.HTML, SyntaxType.ANNOTATED_XHTML, SyntaxType.ANNOTATED_HTML);
 
     private XHTMLLinkRenderer linkRenderer;
 
@@ -591,7 +586,7 @@ public class XHTMLChainingRenderer extends AbstractChainingPrintRenderer
     public void onRawText(String text, Syntax syntax)
     {
         // Directly inject the HTML content in the wiki printer (bypassing the XHTML printer)
-        if (HTML_TYPES.contains(syntax.getType())) {
+        if (SyntaxType.HTML_TYPES.contains(syntax.getType())) {
             getXHTMLWikiPrinter().printRaw(text);
         }
     }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
@@ -586,7 +586,7 @@ public class XHTMLChainingRenderer extends AbstractChainingPrintRenderer
     public void onRawText(String text, Syntax syntax)
     {
         // Directly inject the HTML content in the wiki printer (bypassing the XHTML printer)
-        if (SyntaxType.HTML_TYPES.contains(syntax.getType())) {
+        if (SyntaxType.BROWSER_TYPES.contains(syntax.getType())) {
             getXHTMLWikiPrinter().printRaw(text);
         }
     }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
@@ -586,7 +586,7 @@ public class XHTMLChainingRenderer extends AbstractChainingPrintRenderer
     public void onRawText(String text, Syntax syntax)
     {
         // Directly inject the HTML content in the wiki printer (bypassing the XHTML printer)
-        if (SyntaxType.BROWSER_TYPES.contains(syntax.getType())) {
+        if (SyntaxType.HTML_FAMILY_TYPES.contains(syntax.getType())) {
             getXHTMLWikiPrinter().printRaw(text);
         }
     }


### PR DESCRIPTION
These changes are related to a PR opened on the xwiki-platform https://github.com/xwiki/xwiki-platform/pull/1700#discussion_r726829978