### PR TITLE
XRENDERING-629: The figure and figure caption should not be part of the editable content

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
@@ -603,8 +603,6 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     @Override
     public void beginFigureCaption(Map<String, String> parameters)
     {
-        ++this.inlineDepth;
-
         super.beginFigureCaption(parameters);
     }
 
@@ -613,7 +611,6 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     {
         super.endFigureCaption(parameters);
 
-        --this.inlineDepth;
         this.previousEvent = Event.FIGURE_CAPTION;
     }
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
@@ -94,7 +94,6 @@ public class FigureCaptionMacro extends AbstractNoParameterMacro
         {
             XDOM xdom = this.contentParser.parse(content, context, false, false);
             List<Block> figureCaptionChildren = xdom.getChildren();
-            this.parserUtils.removeTopLevelParagraph(figureCaptionChildren);
 
             // Mark the macro content as being content that has not been transformed (so that it can editable inline)
             figureCaptionChildren = Collections.singletonList(new MetaDataBlock(figureCaptionChildren,

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureCaptionMacro.java
@@ -89,15 +89,17 @@ public class FigureCaptionMacro extends AbstractNoParameterMacro
 
         // If we're not inside a FigureBlock then don't do anything.
         Block parent = context.getCurrentMacroBlock().getParent();
-        if (parent instanceof FigureBlock) {
+        if (parent instanceof FigureBlock
+            || (parent instanceof MetaDataBlock && parent.getParent() instanceof FigureBlock))
+        {
             XDOM xdom = this.contentParser.parse(content, context, false, false);
             List<Block> figureCaptionChildren = xdom.getChildren();
             this.parserUtils.removeTopLevelParagraph(figureCaptionChildren);
-            figureCaptionChildren = Collections.singletonList(new FigureCaptionBlock(figureCaptionChildren));
 
             // Mark the macro content as being content that has not been transformed (so that it can editable inline)
-            result = Collections.singletonList(new MetaDataBlock(figureCaptionChildren,
+            figureCaptionChildren = Collections.singletonList(new MetaDataBlock(figureCaptionChildren,
                 getNonGeneratedContentMetaData()));
+            result = Collections.singletonList(new FigureCaptionBlock(figureCaptionChildren));
         }
 
         return result;

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/main/java/org/xwiki/rendering/internal/macro/figure/FigureMacro.java
@@ -82,9 +82,10 @@ public class FigureMacro extends AbstractNoParameterMacro
         throws MacroExecutionException
     {
         XDOM xdom = this.contentParser.parse(content, context, false, false);
-        List<Block> contentBlock = Collections.singletonList(new FigureBlock(xdom.getChildren()));
-
         // Mark the macro content as being content that has not been transformed (so that it can editable inline)
-        return Collections.singletonList(new MetaDataBlock(contentBlock, getNonGeneratedContentMetaData()));
+        List<Block> contentBlock = Collections.singletonList(new MetaDataBlock(xdom.getChildren(),
+            getNonGeneratedContentMetaData()));
+
+        return Collections.singletonList(new FigureBlock(contentBlock));
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure1.test
@@ -21,7 +21,9 @@ beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block
 beginMacroMarkerStandalone [figureCaption] [] [caption]
 beginFigureCaption
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
 onWord [caption]
+endParagraph
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
 endMacroMarkerStandalone [figureCaption] [] [caption]
@@ -43,4 +45,4 @@ endDocument
 .# The main problem is that ATM we don't have a way to input FigureBlock/FigureCaptionBlock without
 .# resorting to the XWiki 2.0+ syntax and Transformations.
 .#--------------------------------------------------------------------------------------------------
-<p>caption</p><p>whatever1<br/>whatever2</p>
+<div class="figcaption"><p>caption</p></div><p>whatever1<br/>whatever2</p>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
@@ -16,22 +16,22 @@ beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 
 {{figureCaption}}caption{{/figureCaption}}]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
 onWord [whatever1]
 onNewLine
 onWord [whatever2]
 endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigureCaption
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 onWord [caption]
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
-endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMacroMarkerStandalone [figureCaption] [] [caption]
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure2.test
@@ -26,7 +26,9 @@ endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
 beginFigureCaption
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
 onWord [caption]
+endParagraph
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
 endMacroMarkerStandalone [figureCaption] [] [caption]
@@ -43,4 +45,4 @@ endDocument
 .# The main problem is that ATM we don't have a way to input FigureBlock/FigureCaptionBlock without
 .# resorting to the XWiki 2.0+ syntax and Transformations.
 .#--------------------------------------------------------------------------------------------------
-<p>whatever1<br/>whatever2</p><p>caption</p>
+<p>whatever1<br/>whatever2</p><div class="figcaption"><p>caption</p></div>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure3.test
@@ -12,15 +12,15 @@ whatever2
 beginDocument
 beginMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
 onWord [whatever1]
 onNewLine
 onWord [whatever2]
 endParagraph
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [whatever1
 whatever2]
 endDocument

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure4.test
@@ -17,34 +17,34 @@
 .#-----------------------------------------------------
 beginDocument
 beginMacroMarkerStandalone [figure] [] [{{figureCaption}}{{/figureCaption}}]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
-beginMacroMarkerStandalone [figureCaption] [] []
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginMacroMarkerStandalone [figureCaption] [] []
 beginFigureCaption
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
-endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMacroMarkerStandalone [figureCaption] [] []
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [{{figureCaption}}{{/figureCaption}}]
 beginMacroMarkerStandalone [figure] []
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
-endFigure
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] []
 beginMacroMarkerStandalone [figure] [] [{{figureCaption/}}]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
-beginMacroMarkerStandalone [figureCaption] []
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginMacroMarkerStandalone [figureCaption] []
 beginFigureCaption
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
-endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMacroMarkerStandalone [figureCaption] []
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [{{figureCaption/}}]
 endDocument
 .#--------------------------------------------------------------------------------------------------

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure4.test
@@ -53,4 +53,4 @@ endDocument
 .# The main problem is that ATM we don't have a way to input FigureBlock/FigureCaptionBlock without
 .# resorting to the XWiki 2.0+ syntax and Transformations.
 .#--------------------------------------------------------------------------------------------------
-<p></p><p></p>
+<div class="figcaption"></div><div class="figcaption"></div>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
@@ -3,21 +3,22 @@
 .input|xwiki/2.0
 .#-----------------------------------------------------
 {{figure}}
-{{figureCaption}}caption{{/figureCaption}}
+[[image:Space.ExistingPage@my.png]]
 
-whatever1
-whatever2
+{{figureCaption}}caption{{/figureCaption}}
 {{/figure}}
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
-beginMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption}}
+beginMacroMarkerStandalone [figure] [] [[[image:Space.ExistingPage@my.png]]
 
-whatever1
-whatever2]
+{{figureCaption}}caption{{/figureCaption}}]
 beginFigure
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
+onImage [Typed = [false] Type = [url] Reference = [Space.ExistingPage@my.png]] [false]
+endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
 beginFigureCaption
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
@@ -25,22 +26,24 @@ onWord [caption]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
 endMacroMarkerStandalone [figureCaption] [] [caption]
-beginParagraph
-onWord [whatever1]
-onNewLine
-onWord [whatever2]
-endParagraph
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigure
-endMacroMarkerStandalone [figure] [] [{{figureCaption}}caption{{/figureCaption}}
+endMacroMarkerStandalone [figure] [] [[[image:Space.ExistingPage@my.png]]
 
-whatever1
-whatever2]
+{{figureCaption}}caption{{/figureCaption}}]
 endDocument
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{figure}}
+[[image:Space.ExistingPage@my.png]]
+
+{{figureCaption}}caption{{/figureCaption}}
+{{/figure}}
 .#--------------------------------------------------------------------------------------------------
 .expect|xhtml/1.0
 .# This test should be in the Syntax - XHTML modules but that would cause a cyclic dependency issue.
 .# The main problem is that ATM we don't have a way to input FigureBlock/FigureCaptionBlock without
 .# resorting to the XWiki 2.0+ syntax and Transformations.
 .#--------------------------------------------------------------------------------------------------
-<p>caption</p><p>whatever1<br/>whatever2</p>
+<p><img src="Space.ExistingPage@my.png" alt="Space.ExistingPage@my.png"/></p><p>caption</p>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
@@ -24,7 +24,9 @@ endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [caption]
 beginFigureCaption
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
 onWord [caption]
+endParagraph
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
 endMacroMarkerStandalone [figureCaption] [] [caption]
@@ -48,4 +50,4 @@ endDocument
 .# The main problem is that ATM we don't have a way to input FigureBlock/FigureCaptionBlock without
 .# resorting to the XWiki 2.0+ syntax and Transformations.
 .#--------------------------------------------------------------------------------------------------
-<p><img src="Space.ExistingPage@my.png" alt="Space.ExistingPage@my.png"/></p><p>caption</p>
+<p><img src="Space.ExistingPage@my.png" alt="Space.ExistingPage@my.png"/></p><div class="figcaption"><p>caption</p></div>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-figure/src/test/resources/macrofigure5.test
@@ -1,7 +1,9 @@
 .runTransformations:macro
-.#-----------------------------------------------------
+.#--------------------------------------------------------------------------------------------------
 .input|xwiki/2.0
-.#-----------------------------------------------------
+.# Test with image content to ensure later changes to rendering/parsing figures with images do not
+.# break the figure macro.
+.#--------------------------------------------------------------------------------------------------
 {{figure}}
 [[image:Space.ExistingPage@my.png]]
 

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html5/src/test/resources/html50/specific/figure/figure1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html5/src/test/resources/html50/specific/figure/figure1.test
@@ -10,4 +10,4 @@ whatever
 .#-----------------------------------------------------
 .expect|html/5.0
 .#-----------------------------------------------------
-<figure><p>whatever</p><figcaption>caption</figcaption></figure>
+<figure><p>whatever</p><figcaption><p>caption</p></figcaption></figure>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRenderer.java
@@ -40,6 +40,7 @@ import org.xwiki.rendering.renderer.printer.WikiPrinter;
 import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.syntax.SyntaxType;
+import org.xwiki.xml.html.HTMLConstants;
 
 /**
  * Convert listener events to XHTML.
@@ -594,16 +595,17 @@ public class XHTMLChainingRenderer extends AbstractChainingPrintRenderer
     @Override
     public void beginFigureCaption(Map<String, String> parameters)
     {
-        // FigureCaptionBlock contain inline elements and must be converted to standalone. We add a paragraph around
-        // them to have some nice fallback (since <figure>/<figcaption> tags are not supported in XHTML 1.0).
-        getXHTMLWikiPrinter().printXMLStartElement("p", parameters);
+        // We add a div to have some nice fallback (since <figure>/<figcaption> tags are not supported in XHTML 1.0).
+        Map<String, String> extendedParameters = new LinkedHashMap<>(parameters);
+        addClassValue(HTMLConstants.ATTRIBUTE_CLASS, "figcaption", extendedParameters);
+        getXHTMLWikiPrinter().printXMLStartElement(HTMLConstants.TAG_DIV, extendedParameters);
     }
 
     @Override
     public void endFigureCaption(Map<String, String> parameters)
     {
         // See beginFigureCaption()
-        getXHTMLWikiPrinter().printXMLEndElement("p");
+        getXHTMLWikiPrinter().printXMLEndElement(HTMLConstants.TAG_DIV);
     }
 
     private void addClassValue(String classAttributeName, String newClassValue, Map<String, String> attributes)

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRendererTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLChainingRendererTest.java
@@ -51,7 +51,7 @@ class XHTMLChainingRendererTest
         renderer.onWord("caption");
         renderer.endFigureCaption(Collections.emptyMap());
 
-        assertEquals("<p>caption</p>", wikiPrinter.toString());
+        assertEquals("<div class=\"figcaption\">caption</div>", wikiPrinter.toString());
     }
 
     @Test

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/AbstractStackingInlineContentChainingListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/AbstractStackingInlineContentChainingListener.java
@@ -104,6 +104,13 @@ public abstract class AbstractStackingInlineContentChainingListener extends Look
     }
 
     @Override
+    public void beginFigureCaption(Map<String, String> parameters)
+    {
+        startStandaloneElement();
+        super.beginFigureCaption(parameters);
+    }
+
+    @Override
     public void endGroup(Map<String, String> parameters)
     {
         super.endGroup(parameters);
@@ -142,6 +149,13 @@ public abstract class AbstractStackingInlineContentChainingListener extends Look
     public void endFigure(Map<String, String> parameters)
     {
         super.endFigure(parameters);
+        endStandaloneElement();
+    }
+
+    @Override
+    public void endFigureCaption(Map<String, String> parameters)
+    {
+        super.endFigureCaption(parameters);
         endStandaloneElement();
     }
 


### PR DESCRIPTION
* Put the `FigureBlock` and `FigureCaptionBlock` outside the `MetaDataBlock` that wraps the editable content.
* Mark `FigureCaptionBlock` as container for block-level elements. This is consistent with HTML5 and required to keep the caption editable in CKEditor.
* Add a new test case that contains an image.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-629