### PR TITLE
XRENDERING-630: The annotated HTML5 renderer doesn't render all metadata for macros

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/test/resources/macrohtml19.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/test/resources/macrohtml19.test
@@ -47,4 +47,4 @@ another html content--><p>html content</p><div><div class="xwiki-metadata-contai
 .#-----------------------------------------------------
 <!--startmacro:html|-|wiki="true"|-|html content
 ((({{testmetadatamacro/}})))
-another html content--><p>html content</p><div>testmacro</div><p>another html content</p><!--stopmacro-->
+another html content--><p>html content</p><div><div class="xwiki-metadata-container" data-xwiki-mymetadata="metadatavalue">testmacro</div></div><p>another html content</p><!--stopmacro-->

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5ChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5ChainingRenderer.java
@@ -22,8 +22,10 @@ package org.xwiki.rendering.internal.renderer.html5;
 import java.util.Map;
 
 import org.xwiki.rendering.internal.renderer.xhtml.XHTMLMacroRenderer;
+import org.xwiki.rendering.internal.renderer.xhtml.XHTMLMetaDataRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
+import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.listener.chaining.BlockStateChainingListener;
 import org.xwiki.rendering.listener.chaining.ListenerChain;
 
@@ -39,7 +41,12 @@ public class AnnotatedHTML5ChainingRenderer extends HTML5ChainingRenderer
     /**
      * Renders a Macro definition into Annotated XHTML.
      */
-    private XHTMLMacroRenderer macroRenderer;
+    private final XHTMLMacroRenderer macroRenderer;
+
+    /**
+     * Renders metadata into Annotated XHTML.
+     */
+    private final XHTMLMetaDataRenderer metaDataRenderer;
 
     /**
      * @param linkRenderer the object to render link events into XHTML. This is done so that it's pluggable because link
@@ -56,6 +63,8 @@ public class AnnotatedHTML5ChainingRenderer extends HTML5ChainingRenderer
         super(linkRenderer, imageRenderer, listenerChain);
 
         this.macroRenderer = new XHTMLMacroRenderer();
+
+        this.metaDataRenderer = new XHTMLMetaDataRenderer();
     }
 
     @Override
@@ -69,21 +78,37 @@ public class AnnotatedHTML5ChainingRenderer extends HTML5ChainingRenderer
     @Override
     public void beginMacroMarker(String name, Map<String, String> parameters, String content, boolean isInline)
     {
-        if (getBlockState().getMacroDepth() == 1) {
-            // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
-            // so that the macro can be reconstructed when moving back from XHTML to XDOM.
-            this.macroRenderer.beginRender(getXHTMLWikiPrinter(), name, parameters, content);
-        }
+        // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
+        // so that the macro can be reconstructed when moving back from XHTML to XDOM.
+        this.macroRenderer.beginRender(getXHTMLWikiPrinter(), name, parameters, content);
     }
 
     @Override
     public void endMacroMarker(String name, Map<String, String> parameters, String content, boolean isInline)
     {
-        if (getBlockState().getMacroDepth() == 1) {
-            // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
-            // so that the macro can be reconstructed when moving back from XHTML to XDOM.
-            this.macroRenderer.endRender(getXHTMLWikiPrinter());
-        }
+        // Do not do any rendering but we still need to save the macro definition in some hidden XHTML
+        // so that the macro can be reconstructed when moving back from XHTML to XDOM.
+        this.macroRenderer.endRender(getXHTMLWikiPrinter());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @since 14.0RC1
+     */
+    @Override
+    public void beginMetaData(MetaData metadata)
+    {
+        this.metaDataRenderer.beginRender(getXHTMLWikiPrinter(), getBlockState().isInLine(), metadata);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @since 14.0RC1
+     */
+    @Override
+    public void endMetaData(MetaData metadata)
+    {
+        this.metaDataRenderer.endRender(getXHTMLWikiPrinter(), getBlockState().isInLine());
     }
 
     /**

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/java/org/xwiki/rendering/internal/html5/AnnotatedHTML5SpecificTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/java/org/xwiki/rendering/internal/html5/AnnotatedHTML5SpecificTest.java
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.html5;
+
+import org.xwiki.rendering.test.integration.junit5.RenderingTests;
+
+/**
+ * Run all specific tests found in {@code *.test} files located in the classpath. These {@code *.test} files must follow
+ * the conventions described in {@link org.xwiki.rendering.test.integration.TestDataParser}.
+ *
+ * @version $Id$
+ */
+@RenderingTests.Scope(value = "annotatedhtml50.specific")
+public class AnnotatedHTML5SpecificTest implements RenderingTests
+{
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/simple/metadata/metadata1.out.txt
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/simple/metadata/metadata1.out.txt
@@ -1,1 +1,0 @@
-<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/simple/metadata/metadata1.out.txt
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/simple/metadata/metadata1.out.txt
@@ -1,0 +1,1 @@
+<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/specific/metadata/metadata1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/test/resources/annotatedhtml50/specific/metadata/metadata1.test
@@ -1,0 +1,9 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Verify that metadata is kept in the output.
+.#-----------------------------------------------------
+<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>
+.#-----------------------------------------------------
+.expect|annotatedhtml/5.0
+.#-----------------------------------------------------
+<div data-xwiki-syntax="xwiki/2.0" class="xwiki-metadata-container"><div><p>Heading</p></div></div>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -19,10 +19,8 @@
  */
 package org.xwiki.rendering.internal.renderer.xhtml;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.listener.MetaData;
@@ -40,7 +38,12 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
     /**
      * Renders a Macro definition into Annotated XHTML.
      */
-    private XHTMLMacroRenderer macroRenderer;
+    private final XHTMLMacroRenderer macroRenderer;
+
+    /**
+     * Renders metadata into Annotated XHTML.
+     */
+    private final XHTMLMetaDataRenderer metaDataRenderer;
 
     /**
      * @param linkRenderer the object to render link events into XHTML. This is done so that it's pluggable because link
@@ -57,6 +60,8 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
         super(linkRenderer, imageRenderer, listenerChain);
 
         this.macroRenderer = new XHTMLMacroRenderer();
+
+        this.metaDataRenderer = new XHTMLMetaDataRenderer();
     }
 
     @Override
@@ -83,36 +88,15 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
         this.macroRenderer.endRender(getXHTMLWikiPrinter());
     }
 
-    /**
-     * @return a span element if we are inside an inline macro. Else a div.
-     */
-    private String getMetadataContainerElement()
-    {
-        if (getBlockState().isInLine()) {
-            return "span";
-        } else {
-            return "div";
-        }
-    }
-
     @Override
     public void beginMetaData(MetaData metadata)
     {
-        Map<String, String> attributes = new LinkedHashMap<>();
-
-        for (Map.Entry<String, Object> metadataPair : metadata.getMetaData().entrySet()) {
-            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadataPair.getKey(),
-                metadataPair.getValue().toString());
-        }
-
-        attributes.put("class", XHTMLXWikiGeneratorListener.METADATA_CONTAINER_CLASS);
-
-        this.getXHTMLWikiPrinter().printXMLStartElement(getMetadataContainerElement(), attributes);
+        this.metaDataRenderer.beginRender(getXHTMLWikiPrinter(), getBlockState().isInLine(), metadata);
     }
 
     @Override
     public void endMetaData(MetaData metadata)
     {
-        getXHTMLWikiPrinter().printXMLEndElement(getMetadataContainerElement());
+        this.metaDataRenderer.endRender(getXHTMLWikiPrinter(), getBlockState().isInLine());
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.renderer.xhtml;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
+import org.xwiki.rendering.listener.MetaData;
+import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Renders metadata into Annotated XHTML, i.e., a div or span with the metadata as attributes.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+@Unstable
+public class XHTMLMetaDataRenderer
+{
+    /**
+     * @return a span element if we are inside an inline macro. Else a div.
+     */
+    private String getMetadataContainerElement(boolean inline)
+    {
+        if (inline) {
+            return "span";
+        } else {
+            return "div";
+        }
+    }
+
+    /**
+     * Render the open tag of the metadata.
+     *
+     * @param printer The output printer.
+     * @param inline If the current context is an inline context, i.e., only phrasing content is allowed.
+     * @param metaData The metadata to render.
+     */
+    public void beginRender(XHTMLWikiPrinter printer, boolean inline, MetaData metaData)
+    {
+        Map<String, String> attributes = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Object> metadataPair : metaData.getMetaData().entrySet()) {
+            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadataPair.getKey(),
+                metadataPair.getValue().toString());
+        }
+
+        attributes.put("class", XHTMLXWikiGeneratorListener.METADATA_CONTAINER_CLASS);
+
+        printer.printXMLStartElement(getMetadataContainerElement(inline), attributes);
+    }
+
+    /**
+     * Render the closing tag of the metadata.
+     *
+     * @param printer The output print.
+     * @param inline If the current context is an inline context, i.e., only phrasing content is allowed.
+     */
+    public void endRender(XHTMLWikiPrinter printer, boolean inline)
+    {
+        printer.printXMLEndElement(getMetadataContainerElement(inline));
+    }
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
-import org.xwiki.stability.Unstable;
 
 /**
  * Renders metadata into Annotated XHTML, i.e., a div or span with the metadata as attributes.
@@ -33,7 +32,6 @@ import org.xwiki.stability.Unstable;
  * @version $Id$
  * @since 14.0RC1
  */
-@Unstable
 public class XHTMLMetaDataRenderer
 {
     /**


### PR DESCRIPTION
* Render macro markers also for nested macros
* Extract a class XHTMLMetaDataRenderer to avoid code duplication
* Render metadata blocks
* Add metadata test to the annotated HTML5 renderer

Jira issue: https://jira.xwiki.org/browse/XRENDERING-630