### PR TITLE
XRENDERING-612: Mailto links are incorrectly parsed (fix)

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/link/link6.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/link/link6.test
@@ -1,5 +1,6 @@
 .#-----------------------------------------------------
 .input|xhtml/1.0
+.# Testing mailto link recognition without metadata.
 .#-----------------------------------------------------
 <p>one <a href="mailto:john@doe.com">two</a> three</p>
 .#-----------------------------------------------------


### PR DESCRIPTION
* Add mising comment to test

Original Jira issue: https://jira.xwiki.org/browse/XRENDERING-612 - fixing https://github.com/xwiki/xwiki-rendering/pull/196#discussion_r783900776