### PR TITLE
XRENDERING-6: Id are not unique when included document or macro content has the same headers as the top document

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/HeaderBlock.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/HeaderBlock.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.rendering.listener.HeaderLevel;
 import org.xwiki.rendering.listener.Listener;
+import org.xwiki.stability.Unstable;
 
 /**
  * @version $Id$
@@ -105,6 +106,16 @@ public class HeaderBlock extends AbstractBlock
     public String getId()
     {
         return this.id;
+    }
+
+    /**
+     * @param id the id of the header to set
+     * @since 14.2RC1
+     */
+    @Unstable
+    public void setId(String id)
+    {
+        this.id = id;
     }
 
     /**

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/ImageBlock.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/ImageBlock.java
@@ -114,7 +114,17 @@ public class ImageBlock extends AbstractBlock
     }
 
     /**
-     * @return the id of the image.
+     * @param id the id of the image to set
+     * @since 14.2RC1
+     */
+    @Unstable
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+
+    /**
+     * @return the id of the image
      * @since 14.2RC1
      */
     @Unstable

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/parser/Parser.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/parser/Parser.java
@@ -24,6 +24,8 @@ import java.io.Reader;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.util.IdGenerator;
+import org.xwiki.stability.Unstable;
 
 /**
  * Parse content into a XDOM (a tree of {@link org.xwiki.rendering.block.Block}s).
@@ -46,4 +48,18 @@ public interface Parser
      *             should be written to not generate any error as much as possible.
      */
     XDOM parse(Reader source) throws ParseException;
+
+    /**
+     * @param source the content to parse
+     * @param idGenerator the id generator to use for automatically generating ids during parsing
+     * @return the tree representation of the content as {@link org.xwiki.rendering.block.Block}s
+     * @throws ParseException if the source cannot be read or an unexpected error happens during the parsing.
+     *     Parsers should be written to not generate any error as much as possible.
+     * @since 14.2RC1
+     */
+    @Unstable
+    default XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
+        return parse(source);
+    }
 }

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/parser/StreamParser.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/parser/StreamParser.java
@@ -24,6 +24,8 @@ import java.io.Reader;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.util.IdGenerator;
+import org.xwiki.stability.Unstable;
 
 /**
  * Streaming based parser. Instead of returning a resulting XDOM it send events during the parsing.
@@ -46,4 +48,19 @@ public interface StreamParser
      *             should be written to not generate any error as much as possible.
      */
     void parse(Reader source, Listener listener) throws ParseException;
+
+    /**
+     * @param source the content to parse
+     * @param listener the listener that receives an event for each element
+     * @param idGenerator the id generator to use for automatically generating ids during parsing
+     * @throws ParseException if the source cannot be read or an unexpected error happens during the parsing.
+     *     Parsers should be written to not generate any error as much as possible.
+     * @since 14.2RC1
+     */
+    @Unstable
+    default void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    {
+        parse(source, listener);
+    }
+
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox10.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/resources/macrobox10.test
@@ -1,0 +1,45 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.# Ensure that heading and image ids are not duplicated by the box macro.
+.#-----------------------------------------------------
+{{box}}
+= Heading =
+
+image:icon:accept
+{{/box}}
+
+= Heading =
+
+image:icon:accept
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [box] [] [= Heading =
+
+image:icon:accept]
+beginGroup [[class]=[box]]
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginSection
+beginHeader [1, HHeading-1]
+onWord [Heading]
+endHeader [1, HHeading-1]
+beginParagraph
+onImage [Typed = [false] Type = [url] Reference = [icon:accept]] [true] [Iicon:accept-1]
+endParagraph
+endSection
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endGroup [[class]=[box]]
+endMacroMarkerStandalone [box] [] [= Heading =
+
+image:icon:accept]
+beginSection
+beginHeader [1, HHeading]
+onWord [Heading]
+endHeader [1, HHeading]
+beginParagraph
+onImage [Typed = [false] Type = [url] Reference = [icon:accept]] [true] [Iicon:accept]
+endParagraph
+endSection
+endDocument

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-doxia/src/main/java/org/xwiki/rendering/internal/parser/doxia/AbstractDoxiaParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-doxia/src/main/java/org/xwiki/rendering/internal/parser/doxia/AbstractDoxiaParser.java
@@ -65,6 +65,12 @@ public abstract class AbstractDoxiaParser implements Parser, StreamParser
     public XDOM parse(Reader source) throws ParseException
     {
         IdGenerator idGenerator = new IdGenerator();
+        return parse(source, idGenerator);
+    }
+
+    @Override
+    public XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
         XDOMGeneratorListener listener = new XDOMGeneratorListener();
         parse(source, listener, idGenerator);
 
@@ -82,14 +88,8 @@ public abstract class AbstractDoxiaParser implements Parser, StreamParser
         parse(source, listener, idGenerator);
     }
 
-    /**
-     * @param source the content to parse
-     * @param listener receive event for each element
-     * @param idGenerator unique id tool generator
-     * @throws ParseException if the source cannot be read or an unexpected error happens during the parsing. Parsers
-     *             should be written to not generate any error as much as possible.
-     */
-    private void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    @Override
+    public void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
     {
         XWikiGeneratorSink doxiaSink =
             new XWikiGeneratorSink(listener, this.linkReferenceParser, this.plainRendererFactory, idGenerator,

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html/src/main/java/org/xwiki/rendering/internal/parser/html/HTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html/src/main/java/org/xwiki/rendering/internal/parser/html/HTMLParser.java
@@ -32,6 +32,7 @@ import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
 import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.util.IdGenerator;
 import org.xwiki.xml.html.HTMLCleaner;
 import org.xwiki.xml.html.HTMLUtils;
 
@@ -67,8 +68,20 @@ public class HTMLParser extends XHTMLParser
     }
 
     @Override
+    public XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
+        return super.parse(new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source))), idGenerator);
+    }
+
+    @Override
     public void parse(Reader source, Listener listener) throws ParseException
     {
         super.parse(new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source))), listener);
+    }
+
+    @Override
+    public void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    {
+        super.parse(new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source))), listener, idGenerator);
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html5/src/main/java/org/xwiki/rendering/internal/parser/html5/HTML5Parser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-html5/src/main/java/org/xwiki/rendering/internal/parser/html5/HTML5Parser.java
@@ -33,6 +33,7 @@ import org.xwiki.rendering.internal.parser.xhtml5.XHTML5Parser;
 import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.util.IdGenerator;
 import org.xwiki.stability.Unstable;
 import org.xwiki.xml.html.HTMLCleaner;
 import org.xwiki.xml.html.HTMLCleanerConfiguration;
@@ -65,10 +66,25 @@ public class HTML5Parser extends XHTML5Parser
     }
 
     @Override
+    public XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
+        return super.parse(
+            new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source, getHTMLCleanerConfiguration()))),
+            idGenerator);
+    }
+
+    @Override
     public void parse(Reader source, Listener listener) throws ParseException
     {
         super.parse(new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source, getHTMLCleanerConfiguration()))),
             listener);
+    }
+
+    @Override
+    public void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    {
+        super.parse(new StringReader(HTMLUtils.toString(this.htmlCleaner.clean(source, getHTMLCleanerConfiguration()))),
+            listener, idGenerator);
     }
 
     @Override

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/AbstractWikiModelParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/AbstractWikiModelParser.java
@@ -91,6 +91,12 @@ public abstract class AbstractWikiModelParser implements Parser, WikiModelStream
     public XDOM parse(Reader source) throws ParseException
     {
         IdGenerator idGenerator = new IdGenerator();
+        return parse(source, idGenerator);
+    }
+
+    @Override
+    public XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
         XDOMGeneratorListener listener = new XDOMGeneratorListener();
         parse(source, listener, idGenerator);
 
@@ -116,14 +122,12 @@ public abstract class AbstractWikiModelParser implements Parser, WikiModelStream
     }
 
     /**
-     * @param source the content to parse
-     * @param listener receive event for each element
-     * @param idGenerator unique id tool generator
-     * @throws ParseException if the source cannot be read or an unexpected error happens during the parsing. Parsers
-     *             should be written to not generate any error as much as possible.
+    * {@inheritDoc}
+     *
      * @since 2.1RC1
      */
-    protected void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    @Override
+    public void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
     {
         IWikiParser parser = createWikiModelParser();
         try {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/DefaultXWikiGeneratorListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/DefaultXWikiGeneratorListener.java
@@ -760,7 +760,7 @@ public class DefaultXWikiGeneratorListener implements XWikiGeneratorListener
                     }
                 };
                 wrapper.setWrappedListener(getListener());
-                this.parser.parse(new StringReader(this.imageLabel), wrapper);
+                this.parser.parse(new StringReader(this.imageLabel), wrapper, this.idGenerator);
             } catch (ParseException e) {
                 // TODO what should we do here ?
             }
@@ -955,7 +955,7 @@ public class DefaultXWikiGeneratorListener implements XWikiGeneratorListener
             try {
                 // TODO: Use an inline parser. See https://jira.xwiki.org/browse/XWIKI-2748
                 WikiModelParserUtils parserUtils = new WikiModelParserUtils();
-                parserUtils.parseInline(this.parser, label, getListener(), prefix);
+                parserUtils.parseInline(this.parser, label, getListener(), this.idGenerator, prefix);
             } catch (ParseException e) {
                 // TODO what should we do here ?
             }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
@@ -203,6 +203,17 @@ public class XHTMLParser extends AbstractWikiModelParser
     }
 
     @Override
+    public XDOM parse(Reader source, IdGenerator idGenerator) throws ParseException
+    {
+        Reader pushBackReader = getPushBackReader(source);
+        if (pushBackReader != null) {
+            return super.parse(pushBackReader, idGenerator);
+        } else {
+            return new XDOM(Collections.emptyList());
+        }
+    }
+
+    @Override
     public void parse(Reader source, Listener listener) throws ParseException
     {
         Reader pushBackReader = getPushBackReader(source);
@@ -212,7 +223,7 @@ public class XHTMLParser extends AbstractWikiModelParser
     }
 
     @Override
-    protected void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
+    public void parse(Reader source, Listener listener, IdGenerator idGenerator) throws ParseException
     {
         Reader pushBackReader = getPushBackReader(source);
         if (pushBackReader != null) {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/image/image4.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/image/image4.test
@@ -1,0 +1,19 @@
+.#-------------------------------------------------------------------------------------------------------
+.inputexpect|xwiki/2.0
+.# Test that nested images in links get unique ids.
+.#-------------------------------------------------------------------------------------------------------
+[[image:image.png>>https://xwiki.org]] [[image:image.png>>https://xwiki.org]]
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+beginLink [Typed = [false] Type = [url] Reference = [https://xwiki.org]] [false]
+onImage [Typed = [false] Type = [url] Reference = [image.png]] [true] [Iimage.png]
+endLink [Typed = [false] Type = [url] Reference = [https://xwiki.org]] [false]
+onSpace
+beginLink [Typed = [false] Type = [url] Reference = [https://xwiki.org]] [false]
+onImage [Typed = [false] Type = [url] Reference = [image.png]] [true] [Iimage.png-1]
+endLink [Typed = [false] Type = [url] Reference = [https://xwiki.org]] [false]
+endParagraph
+endDocument

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroContentParser.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroContentParser.java
@@ -107,7 +107,14 @@ public class DefaultMacroContentParser implements MacroContentParser
         MetaData metadata, boolean inline, Syntax syntax) throws MacroExecutionException
     {
         try {
-            XDOM result = getSyntaxParser(syntax).parse(new StringReader(content));
+            XDOM result;
+
+            if (macroContext.getXDOM() != null && macroContext.getXDOM().getIdGenerator() != null) {
+                result = getSyntaxParser(syntax).parse(new StringReader(content),
+                    macroContext.getXDOM().getIdGenerator());
+            } else {
+                result = getSyntaxParser(syntax).parse(new StringReader(content));
+            }
 
             // Inject metadata
             if (metadata != null) {


### PR DESCRIPTION
* Ensure that ids are unique also when nested in links or macros.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-6