### PR TITLE
XRENDERING-668: Attributes starting with data-xwiki- aren't preserved during XHTML parsing

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XHTMLXWikiGeneratorListener.java
@@ -217,31 +217,32 @@ public class XHTMLXWikiGeneratorListener extends DefaultXWikiGeneratorListener
     @Override
     protected void beginGroup(WikiParameters parameters)
     {
-        boolean withoutMetadata = true;
         if (isMetaDataElement(parameters)) {
             MetaData metaData = createMetaData(parameters);
             getListener().beginMetaData(metaData);
-            withoutMetadata = false;
-        }
 
-        WikiParameters cleanParameters = cleanParametersFromMetadata(parameters);
-        if (withoutMetadata || cleanParameters.getSize() > 0) {
-            super.beginGroup(cleanParameters);
+            WikiParameters cleanParameters = cleanParametersFromMetadata(parameters);
+            if (cleanParameters.getSize() > 0) {
+                super.beginGroup(cleanParameters);
+            }
+        } else {
+            super.beginGroup(parameters);
         }
     }
 
     @Override
     protected void endGroup(WikiParameters parameters)
     {
-        boolean withoutMetadata = true;
         if (isMetaDataElement(parameters)) {
-            getListener().endMetaData(createMetaData(parameters));
-            withoutMetadata = false;
-        }
+            MetaData metaData = createMetaData(parameters);
+            getListener().endMetaData(metaData);
 
-        WikiParameters cleanParameters = cleanParametersFromMetadata(parameters);
-        if (withoutMetadata || cleanParameters.getSize() > 0) {
-            super.endGroup(cleanParameters);
+            WikiParameters cleanParameters = cleanParametersFromMetadata(parameters);
+            if (cleanParameters.getSize() > 0) {
+                super.endGroup(cleanParameters);
+            }
+        } else {
+            super.endGroup(parameters);
         }
     }
 
@@ -250,20 +251,19 @@ public class XHTMLXWikiGeneratorListener extends DefaultXWikiGeneratorListener
     {
         WikiParameters wikiParameters = new WikiParameters(format.getParams());
 
-        boolean withoutMetadata = true;
         if (isMetaDataElement(wikiParameters)) {
             getListener().beginMetaData(createMetaData(wikiParameters));
-            withoutMetadata = false;
-        }
+            WikiParameters cleanParameters = cleanParametersFromMetadata(wikiParameters);
+            if (cleanParameters.getSize() > 0 || !format.getStyles().isEmpty()) {
+                WikiFormat newFormat = format;
+                if (wikiParameters.getSize() != cleanParameters.getSize()) {
+                    newFormat = format.setParameters(cleanParameters.toList());
+                }
 
-        WikiParameters cleanParameters = cleanParametersFromMetadata(wikiParameters);
-        if (withoutMetadata || cleanParameters.getSize() > 0 || !format.getStyles().isEmpty()) {
-            WikiFormat newFormat = format;
-            if (wikiParameters.getSize() != cleanParameters.getSize()) {
-                newFormat = format.setParameters(cleanParameters.toList());
+                super.beginFormat(newFormat);
             }
-
-            super.beginFormat(newFormat);
+        } else {
+            super.beginFormat(format);
         }
     }
 
@@ -272,20 +272,20 @@ public class XHTMLXWikiGeneratorListener extends DefaultXWikiGeneratorListener
     {
         WikiParameters wikiParameters = new WikiParameters(format.getParams());
 
-        boolean withoutMetadata = true;
         if (isMetaDataElement(wikiParameters)) {
             getListener().endMetaData(createMetaData(wikiParameters));
-            withoutMetadata = false;
-        }
 
-        WikiParameters cleanParameters = cleanParametersFromMetadata(wikiParameters);
-        if (withoutMetadata || cleanParameters.getSize() > 0 || !format.getStyles().isEmpty()) {
-            WikiFormat newFormat = format;
-            if (wikiParameters.getSize() != cleanParameters.getSize()) {
-                newFormat = format.setParameters(cleanParameters.toList());
+            WikiParameters cleanParameters = cleanParametersFromMetadata(wikiParameters);
+            if (cleanParameters.getSize() > 0 || !format.getStyles().isEmpty()) {
+                WikiFormat newFormat = format;
+                if (wikiParameters.getSize() != cleanParameters.getSize()) {
+                    newFormat = format.setParameters(cleanParameters.toList());
+                }
+
+                super.endFormat(newFormat);
             }
-
-            super.endFormat(newFormat);
+        } else {
+            super.endFormat(format);
         }
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/group/group1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/group/group1.test
@@ -1,19 +1,19 @@
 .#-----------------------------------------------------
 .input|xhtml/1.0
-.# Verify that STRONG tag parameters are recognized.
+.# Verify that div tag parameters, also starting with data-xwiki-, are recognized.
 .#-----------------------------------------------------
-<p><strong a="b" data-xwiki-parameter="value">something</strong></p>
+<div a="b" data-xwiki-parameter="value">something</div>
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
+beginGroup [[a]=[b][data-xwiki-parameter]=[value]]
 beginParagraph
-beginFormat [BOLD] [[a]=[b][data-xwiki-parameter]=[value]]
 onWord [something]
-endFormat [BOLD] [[a]=[b][data-xwiki-parameter]=[value]]
 endParagraph
+endGroup [[a]=[b][data-xwiki-parameter]=[value]]
 endDocument
 .#-----------------------------------------------------
 .expect|xhtml/1.0
 .#-----------------------------------------------------
-<p><strong><span a="b" data-xwiki-parameter="value">something</span></strong></p>
+<div a="b" data-xwiki-parameter="value"><p>something</p></div>


### PR DESCRIPTION
All tests are passing and I've manually tested editing

```
{{warning}}
Warning!

{{warning}}{{success}}Nested macros are editable!{{/success}}{{/warning}}

{{success}}Success message is inline-editable!{{/success}}
{{/warning}}


(% data-xwiki-attribute="value" %)
(((
Some section content!
)))
```

in the WYSIWYG editor and it worked.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-668