### PR TITLE
XRENDERING-672: Provide a way to list the categories of a macro

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
@@ -19,20 +19,20 @@
  */
 package org.xwiki.rendering.internal.macro;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.properties.ConverterManager;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.MacroCategoryManager;
 import org.xwiki.rendering.macro.MacroId;
@@ -53,6 +53,9 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMess
 @Singleton
 public class DefaultMacroCategoryManager implements MacroCategoryManager
 {
+    @Inject
+    private ConverterManager converterManager;
+
     /**
      * Used to get macro categories defined by the user (if any).
      */
@@ -187,8 +190,8 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
         result.put(macroCategory, ids);
     }
 
-    private Set<String> splitCategories(String s)
+    private Set<String> splitCategories(String categories)
     {
-        return Arrays.stream(s.split("\\s*,\\s*")).collect(Collectors.toSet());
+        return new HashSet<>(this.converterManager.getConverter(List.class).convert(List.class, categories));
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
@@ -53,9 +53,6 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMess
 @Singleton
 public class DefaultMacroCategoryManager implements MacroCategoryManager
 {
-    @Inject
-    private ConverterManager converterManager;
-
     /**
      * Used to get macro categories defined by the user (if any).
      */
@@ -67,6 +64,9 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
      */
     @Inject
     private MacroManager macroManager;
+
+    @Inject
+    private ConverterManager converterManager;
 
     @Inject
     private Logger logger;

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManager.java
@@ -31,13 +31,17 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.MacroCategoryManager;
 import org.xwiki.rendering.macro.MacroId;
 import org.xwiki.rendering.macro.MacroLookupException;
 import org.xwiki.rendering.macro.MacroManager;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.transformation.macro.MacroTransformationConfiguration;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 /**
  * Default implementation of {@link org.xwiki.rendering.macro.MacroCategoryManager}.
@@ -61,6 +65,9 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
     @Inject
     private MacroManager macroManager;
 
+    @Inject
+    private Logger logger;
+
     /**
      * Internal help class to be able to search Macros matching a Macro Id.
      */
@@ -76,7 +83,7 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
     @Override
     public Set<String> getMacroCategories() throws MacroLookupException
     {
-        return getMacroCategories(null);
+        return getMacroCategories((Syntax) null);
     }
 
     @Override
@@ -96,6 +103,25 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
     {
         Set<MacroId> macros = getMacrosGroupedByCategories(syntax).get(category);
         return (null != macros) ? Collections.unmodifiableSet(macros) : Collections.<MacroId>emptySet();
+    }
+
+    @Override
+    public Set<String> getMacroCategories(MacroId macroId)
+    {
+        Properties properties = this.configuration.getCategories();
+        Set<String> categories;
+        if (properties == null || !properties.containsKey(macroId.getId())) {
+            try {
+                Macro<?> macro = this.macroManager.getMacro(macroId);
+                categories = macro.getDescriptor().getDefaultCategories();
+            } catch (MacroLookupException e) {
+                this.logger.warn("Failed to get macro [{}]. Cause: [{}]", macroId, getRootCauseMessage(e));
+                categories = Set.of();
+            }
+        } else {
+            categories = splitCategories((String) properties.get(macroId.getId()));
+        }
+        return categories;
     }
 
     /**
@@ -118,15 +144,14 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
         for (MacroId macroId : macroIds) {
             if (matcher.match(macroId)) {
                 // Check if this macro's category has been overwritten.
-                String macroCategoriesProperty = categories.getProperty(macroId.toString());
+                String macroCategoriesProperty = categories.getProperty(macroId.getId());
 
                 // If not, use the default category set by macro author.
                 Set<String> macroCategories;
                 if (macroCategoriesProperty == null) {
                     macroCategories = this.macroManager.getMacro(macroId).getDescriptor().getDefaultCategories();
                 } else {
-                    macroCategories = Arrays.stream(macroCategoriesProperty.split("\\s+,\\s+"))
-                        .collect(Collectors.toSet());
+                    macroCategories = splitCategories(macroCategoriesProperty);
                 }
 
                 if (macroCategories != null) {
@@ -160,5 +185,10 @@ public class DefaultMacroCategoryManager implements MacroCategoryManager
         }
         ids.add(macroId);
         result.put(macroCategory, ids);
+    }
+
+    private Set<String> splitCategories(String s)
+    {
+        return Arrays.stream(s.split("\\s*,\\s*")).collect(Collectors.toSet());
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroCategoryManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroCategoryManager.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.stability.Unstable;
 
 /**
  * Component interface for managing macro category information. Each rendering macro defines a default category under
@@ -73,4 +74,17 @@ public interface MacroCategoryManager
      * @throws MacroLookupException error when lookup macros
      */
     Set<MacroId> getMacroIds(String category, Syntax syntax) throws MacroLookupException;
+
+    /**
+     * Return the set of categories of a given macro.
+     *
+     * @param macroId the id of the macro to get the category for
+     * @return the list of categories of the macro,
+     * @since 14.6RC1
+     */
+    @Unstable
+    default Set<String> getMacroCategories(MacroId macroId)
+    {
+        return Set.of();
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroCategoryManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroCategoryManager.java
@@ -78,8 +78,8 @@ public interface MacroCategoryManager
     /**
      * Return the set of categories of a given macro.
      *
-     * @param macroId the id of the macro to get the category for
-     * @return the list of categories of the macro,
+     * @param macroId the id of the macro to get the categories for
+     * @return the list of categories of the macro
      * @since 14.6RC1
      */
     @Unstable

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManagerTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroCategoryManagerTest.java
@@ -38,8 +38,7 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
-import ch.qos.logback.classic.Level;
-
+import static ch.qos.logback.classic.Level.WARN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -175,7 +174,7 @@ class DefaultMacroCategoryManagerTest
 
         assertEquals(Set.of(), this.macroCategoryManager.getMacroCategories(macroAId));
         assertEquals("Failed to get macro [macroA]. Cause: [MacroLookupException: ]", this.logCapture.getMessage(0));
-        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals(WARN, this.logCapture.getLogEvent(0).getLevel());
     }
 
     @Test

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroIdFactoryTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroIdFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.macro.MacroId;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.syntax.SyntaxRegistry;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.xwiki.rendering.syntax.Syntax.HTML_5_0;
+
+/**
+ * Test of {@link DefaultMacroIdFactory}.
+ *
+ * @version $Id$
+ * @since 14.6RC1
+ */
+@ComponentTest
+class DefaultMacroIdFactoryTest
+{
+    @InjectMockComponents
+    private DefaultMacroIdFactory macroIdFactory;
+
+    @MockComponent
+    private SyntaxRegistry syntaxRegistry;
+
+    @Test
+    void createMacroId() throws Exception
+    {
+        when(this.syntaxRegistry.resolveSyntax("html/5.0")).thenReturn(HTML_5_0);
+        assertEquals(new MacroId("testMacro", HTML_5_0), this.macroIdFactory.createMacroId("testMacro/html/5.0"));
+    }
+
+    @Test
+    void createMacroIdUnknownSyntax() throws Exception
+    {
+        when(this.syntaxRegistry.resolveSyntax("html/5.0")).thenThrow(ParseException.class);
+        ParseException parseException =
+            assertThrows(ParseException.class, () -> this.macroIdFactory.createMacroId("testMacro/html/5.0"));
+        assertEquals(ParseException.class, parseException.getCause().getClass());
+        assertEquals("Invalid macro id format [testMacro/html/5.0]", parseException.getMessage());
+    }
+}

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.macro;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,7 +34,6 @@ import org.xwiki.rendering.macro.MacroId;
 import org.xwiki.rendering.macro.MacroLookupException;
 import org.xwiki.rendering.macro.MacroNotFoundException;
 import org.xwiki.rendering.syntax.Syntax;
-
 import org.xwiki.rendering.syntax.SyntaxType;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 import org.xwiki.test.LogLevel;
@@ -73,8 +73,8 @@ class DefaultMacroManagerTest
     private class TestInvalidMacro extends AbstractNoParameterMacro
     {
         /**
-         * @param unusedParameter a parameter that shouldn't be there in a component. We do that to make sure that the
-         *        CM will fail to instantiate this macro and to test this error case.
+         * @param unusedParameter a parameter that shouldn't be there in a component. We do that to make sure that
+         *     the CM will fail to instantiate this macro and to test this error case.
          */
         TestInvalidMacro(String unusedParameter)
         {
@@ -205,9 +205,26 @@ class DefaultMacroManagerTest
 
         assertEquals(1, logCapture.size());
         assertEquals("Invalid Macro descriptor format for hint [macro/invalidsyntax]. The hint should contain either "
-            + "the macro name only or the macro name followed by the syntax for which it is valid. In that case the "
-            + "macro name should be followed by a \"/\" followed by the syntax name followed by another \"/\" followed "
-            + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the system.",
+                + "the macro name only or the macro name followed by the syntax for which it is valid. In that case the "
+                + "macro name should be followed by a \"/\" followed by the syntax name followed by another \"/\" followed "
+                + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the system.",
             logCapture.getMessage(0));
+    }
+
+    @Test
+    void getMacroIds() throws Exception
+    {
+        assertEquals(Set.of(
+            new MacroId("testsimplemacro"),
+            new MacroId("testprioritymacro"),
+            new MacroId("testinlineeditingmacro"),
+            new MacroId("testrecursivemacro"),
+            new MacroId("testformatmacro"),
+            new MacroId("testsyntaxwikimacro"),
+            new MacroId("testnestedmacro"),
+            new MacroId("testcontentmacro"),
+            new MacroId("testsimpleinlinemacro"),
+            new MacroId("testfailingmacro")            
+        ), this.macroManager.getMacroIds());
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
@@ -73,8 +73,8 @@ class DefaultMacroManagerTest
     private class TestInvalidMacro extends AbstractNoParameterMacro
     {
         /**
-         * @param unusedParameter a parameter that shouldn't be there in a component. We do that to make sure that
-         *     the CM will fail to instantiate this macro and to test this error case.
+         * @param unusedParameter a parameter that shouldn't be there in a component. We do that to make sure that the
+         *        CM will fail to instantiate this macro and to test this error case.
          */
         TestInvalidMacro(String unusedParameter)
         {
@@ -205,9 +205,9 @@ class DefaultMacroManagerTest
 
         assertEquals(1, logCapture.size());
         assertEquals("Invalid Macro descriptor format for hint [macro/invalidsyntax]. The hint should contain either "
-                + "the macro name only or the macro name followed by the syntax for which it is valid. In that case the "
-                + "macro name should be followed by a \"/\" followed by the syntax name followed by another \"/\" followed "
-                + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the system.",
+            + "the macro name only or the macro name followed by the syntax for which it is valid. In that case the "
+            + "macro name should be followed by a \"/\" followed by the syntax name followed by another \"/\" followed "
+            + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the system.",
             logCapture.getMessage(0));
     }
 


### PR DESCRIPTION
Introduce `MacroCategoryManager#getMacroCategories(org.xwiki.rendering.macro.MacroId)` and its implementation `DefaultMacroCategoryManager#getMacroCategories(org.xwiki.rendering.macro.MacroId)`

Jira: https://jira.xwiki.org/browse/XRENDERING-672