### PR TITLE
XRENDERING-678: Cannot use HtmlMacro with a syntax installed on a subwiki

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
@@ -118,6 +118,7 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
     private RenderingContext renderingContext;
 
     @Inject
+    @Named("context")
     private ComponentManager componentManager;
 
     /**

--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
@@ -119,7 +120,7 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
 
     @Inject
     @Named("context")
-    private ComponentManager componentManager;
+    private Provider<ComponentManager> componentManagerProvider;
 
     /**
      * Create and initialize the descriptor of the macro.
@@ -311,7 +312,7 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
         if (targetSyntax != null) {
             String hint = HTMLMacroXHTMLRendererFactory.PREFIX_SYNTAX + targetSyntax.toIdString();
             try {
-                result = this.componentManager.getInstance(PrintRendererFactory.class, hint);
+                result = this.componentManagerProvider.get().getInstance(PrintRendererFactory.class, hint);
             } catch (ComponentLookupException ignored) {
                 // Unsupported syntax - keep default.
             }

--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/AbstractRenderingTest.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/AbstractRenderingTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.xwiki.component.descriptor.DefaultComponentDescriptor;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.context.Execution;
@@ -102,6 +103,12 @@ public abstract class AbstractRenderingTest
 
     public void execute() throws Exception
     {
+        // Register the context component manager.
+        DefaultComponentDescriptor<Object> contextCM = new DefaultComponentDescriptor<>();
+        contextCM.setRoleType(ComponentManager.class);
+        contextCM.setRoleHint("context");
+        getComponentManager().registerComponent(contextCM, getComponentManager());
+        
         Map<String, String> originalConfiguration = new HashMap<>();
         if (this.configuration != null) {
             ConfigurationSource configurationSource = getComponentManager().getInstance(ConfigurationSource.class);

--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/AbstractRenderingTest.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/AbstractRenderingTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.xwiki.component.descriptor.DefaultComponentDescriptor;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.context.Execution;
@@ -103,12 +102,6 @@ public abstract class AbstractRenderingTest
 
     public void execute() throws Exception
     {
-        // Register the context component manager.
-        DefaultComponentDescriptor<Object> contextCM = new DefaultComponentDescriptor<>();
-        contextCM.setRoleType(ComponentManager.class);
-        contextCM.setRoleHint("context");
-        getComponentManager().registerComponent(contextCM, getComponentManager());
-        
         Map<String, String> originalConfiguration = new HashMap<>();
         if (this.configuration != null) {
             ConfigurationSource configurationSource = getComponentManager().getInstance(ConfigurationSource.class);


### PR DESCRIPTION
  * Use the appropriate context component manager in HTMLMacro
  * Fix the rendering test to register a context component manager
    instance