### PR TITLE
XRENDERING-660: Get rid of the dependency on the xdom+xml syntax

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/pom.xml
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/pom.xml
@@ -44,13 +44,6 @@
       <artifactId>xwiki-rendering-syntax-wikimodel</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- Runtime dependency -->
-    <!-- TODO: That's very bad and should be fixed by https://jira.xwiki.org/browse/XRENDERING-83 -->
-    <dependency>
-      <groupId>org.xwiki.rendering</groupId>
-      <artifactId>xwiki-rendering-syntax-xdomxmlcurrent</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.xwiki.rendering</groupId>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
@@ -47,13 +47,11 @@ import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.parser.ResourceReferenceParser;
 import org.xwiki.rendering.parser.StreamParser;
-import org.xwiki.rendering.renderer.PrintRendererFactory;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.util.IdGenerator;
 import org.xwiki.rendering.wikimodel.IWikiParser;
 import org.xwiki.rendering.wikimodel.xhtml.XhtmlParser;
 import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
-import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
 import org.xwiki.xml.XMLReaderFactory;
 
 import static org.xwiki.rendering.internal.xhtml.XHTML10SyntaxProvider.XHTML_1_0;
@@ -69,20 +67,6 @@ import static org.xwiki.rendering.internal.xhtml.XHTML10SyntaxProvider.XHTML_1_0
 @Singleton
 public class XHTMLParser extends AbstractWikiModelParser
 {
-    /**
-     * The parser used for the link label parsing. For (x)html parsing, this will be an xwiki 2.0 parser, since it's
-     * more convenient to pass link labels in xwiki syntax. See referred resource for more details.
-     *
-     * @see XWikiCommentHandler#handleLinkCommentStop(TagStack)
-     */
-    @Inject
-    @Named("xdom+xml/current")
-    private StreamParser xmlParser;
-
-    @Inject
-    @Named("xdom+xml/current")
-    private PrintRendererFactory xmlRenderer;
-
     /**
      * @see #getLinkReferenceParser()
      */
@@ -127,7 +111,7 @@ public class XHTMLParser extends AbstractWikiModelParser
     @Override
     public StreamParser getLinkLabelParser()
     {
-        return this.xmlParser;
+        return null;
     }
 
     @Override
@@ -142,7 +126,7 @@ public class XHTMLParser extends AbstractWikiModelParser
         handlers.put("h4", handler);
         handlers.put("h5", handler);
         handlers.put("h6", handler);
-        handlers.put("a", new XWikiReferenceTagHandler(this, this.xmlRenderer));
+        handlers.put("a", new XWikiReferenceTagHandler(this));
         handlers.put("img", new XWikiImageTagHandler());
         handlers.put("span", new XWikiSpanTagHandler(this.componentManager, this));
         // Change the class value indicating that the division is an embedded document. We do this in order to be
@@ -153,8 +137,8 @@ public class XHTMLParser extends AbstractWikiModelParser
 
         XhtmlParser parser = new XhtmlParser();
         parser.setExtraHandlers(handlers);
-        parser.setCommentHandler(new XWikiCommentHandler(this.componentManager, this,
-            this.xmlRenderer, this.xhtmlMarkerResourceReferenceParser));
+        parser.setCommentHandler(
+            new XWikiCommentHandler(this.componentManager, this, this.xhtmlMarkerResourceReferenceParser));
 
         // Construct our own XML filter chain since we want to use our own Comment filter.
         try {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
@@ -29,7 +29,6 @@ import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.internal.parser.XDOMGeneratorListener;
 import org.xwiki.rendering.internal.parser.wikimodel.XWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
-import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.parser.ResourceReferenceParser;
@@ -215,7 +214,7 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
         // see WikiModelXHTMLParser#getLinkLabelParser()
         // see http://code.google.com/p/wikimodel/issues/detail?id=87
         // TODO: remove this workaround when wiki syntax in link labels will be supported by wikimodel
-        Listener linkLabelListener = new XDOMGeneratorListener();
+        XDOMGeneratorListener linkLabelListener = new XDOMGeneratorListener();
         linkLabelListener.beginDocument(MetaData.EMPTY);
 
         XWikiGeneratorListener xwikiListener = this.parser.createXWikiGeneratorListener(linkLabelListener, null);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java
@@ -25,14 +25,14 @@ import java.util.Map;
 
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.internal.parser.XDOMGeneratorListener;
 import org.xwiki.rendering.internal.parser.wikimodel.XWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
+import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.parser.ResourceReferenceParser;
-import org.xwiki.rendering.renderer.PrintRenderer;
-import org.xwiki.rendering.renderer.PrintRendererFactory;
-import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
 import org.xwiki.rendering.renderer.reference.link.URILabelGenerator;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.WikiParameters;
@@ -62,8 +62,6 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
 {
     private XHTMLParser parser;
 
-    private PrintRendererFactory xwikiSyntaxPrintRendererFactory;
-
     private ComponentManager componentManager;
 
     private ResourceReferenceParser xhtmlMarkerResourceReferenceParser;
@@ -80,12 +78,10 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
      *       http://code.google.com/p/wikimodel/issues/detail?id=87
      */
     public XWikiCommentHandler(ComponentManager componentManager, XHTMLParser parser,
-        PrintRendererFactory xwikiSyntaxPrintRendererFactory, 
         ResourceReferenceParser xhtmlMarkerResourceReferenceParser)
     {
         this.componentManager = componentManager;
         this.parser = parser;
-        this.xwikiSyntaxPrintRendererFactory = xwikiSyntaxPrintRendererFactory;
         this.xhtmlMarkerResourceReferenceParser = xhtmlMarkerResourceReferenceParser;
     }
 
@@ -214,22 +210,15 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
         // originally appears in the parsed source) and handle it specially in DefaultXWikiGeneratorListener, with the
         // parser passed as the first parameter in the DefaultXWikiGeneratorListener constructor.
         // Since we cannot get this label as it originally appeared in the HTML source ( we are doing a SAX-like
-        // parsing), we should render the XDOM as HTML to get an HTML label.
-        // Since any syntax would do it, as long as this renderer matches the corresponding
-        // DefaultXWikiGeneratorListener
-        // parser, we use an xwiki 2.1 renderer for it is less complex (no context needed to render xwiki 2.1, no url
-        // resolution needed, no reference validity tests).
+        // parsing), we directly parse it and instead pass the resulting XDOM via the XWikiWikiReference class.
         // see DefaultXWikiGeneratorListener#DefaultXWikiGeneratorListener(Parser, ResourceReferenceParser, ImageParser)
         // see WikiModelXHTMLParser#getLinkLabelParser()
         // see http://code.google.com/p/wikimodel/issues/detail?id=87
         // TODO: remove this workaround when wiki syntax in link labels will be supported by wikimodel
-        DefaultWikiPrinter printer = new DefaultWikiPrinter();
+        Listener linkLabelListener = new XDOMGeneratorListener();
+        linkLabelListener.beginDocument(MetaData.EMPTY);
 
-        PrintRenderer linkLabelRenderer = this.xwikiSyntaxPrintRendererFactory.createRenderer(printer);
-        // Make sure to flush whatever the renderer implementation
-        linkLabelRenderer.beginDocument(MetaData.EMPTY);
-
-        XWikiGeneratorListener xwikiListener = this.parser.createXWikiGeneratorListener(linkLabelRenderer, null);
+        XWikiGeneratorListener xwikiListener = this.parser.createXWikiGeneratorListener(linkLabelListener, null);
 
         stack.pushStackParameter(LINK_LISTENER, xwikiListener);
 
@@ -244,7 +233,7 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
     {
         XWikiGeneratorListener xwikiListener =
             (XWikiGeneratorListener) stack.popStackParameter(LINK_LISTENER);
-        PrintRenderer linkLabelRenderer = (PrintRenderer) xwikiListener.getListener();
+        XDOMGeneratorListener linkLabelRenderer = (XDOMGeneratorListener) xwikiListener.getListener();
 
         // Make sure to flush whatever the renderer implementation
         linkLabelRenderer.endDocument(MetaData.EMPTY);
@@ -253,15 +242,15 @@ public class XWikiCommentHandler extends CommentHandler implements XWikiWikiMode
 
         ResourceReference linkReference = this.xhtmlMarkerResourceReferenceParser.parse(this.commentContentStack.pop());
         WikiParameters linkParams = WikiParameters.EMPTY;
-        String label = null;
+        XDOM label = null;
         if (!isFreeStandingLink) {
-            label = linkLabelRenderer.getPrinter().toString();
+            label = linkLabelRenderer.getXDOM();
 
             // Add the Link reference parameters to the link parameters.
             linkParams = (WikiParameters) stack.getStackParameter(LINK_PARAMETERS);
         }
 
-        WikiReference wikiReference = new XWikiWikiReference(linkReference, label, linkParams, isFreeStandingLink);
+        XWikiWikiReference wikiReference = new XWikiWikiReference(linkReference, label, linkParams, isFreeStandingLink);
         stack.getScannerContext().onReference(wikiReference);
 
         stack.popStackParameter(IS_IN_LINK);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiReferenceTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiReferenceTagHandler.java
@@ -20,16 +20,18 @@
 package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
 import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.internal.parser.XDOMGeneratorListener;
 import org.xwiki.rendering.internal.parser.wikimodel.DefaultXWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.wikimodel.WikiModelStreamParser;
 import org.xwiki.rendering.internal.parser.wikimodel.XWikiGeneratorListener;
-import org.xwiki.rendering.renderer.PrintRenderer;
-import org.xwiki.rendering.renderer.PrintRendererFactory;
-import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.WikiParameters;
-import org.xwiki.rendering.wikimodel.WikiReference;
 import org.xwiki.rendering.wikimodel.impl.WikiScannerContext;
 import org.xwiki.rendering.wikimodel.xhtml.handler.ReferenceTagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
@@ -44,19 +46,26 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
  */
 public class XWikiReferenceTagHandler extends ReferenceTagHandler implements XWikiWikiModelHandler
 {
-    private WikiModelStreamParser parser;
+    /**
+     * URL matching pattern.
+     */
+    private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("[a-zA-Z0-9+.-]*://");
 
-    private PrintRendererFactory xwikiSyntaxPrintRendererFactory;
+    /**
+     * Prefix for mailto-links.
+     */
+    private static final String MAILTO_PREFIX = "mailto:";
+
+    private WikiModelStreamParser parser;
 
     /**
      * @since 2.2.5
      * @todo Remove the need to pass a Parser when WikiModel implements support for wiki syntax in links. See
      *       http://code.google.com/p/wikimodel/issues/detail?id=87
      */
-    public XWikiReferenceTagHandler(WikiModelStreamParser parser, PrintRendererFactory xwikiSyntaxPrintRendererFactory)
+    public XWikiReferenceTagHandler(WikiModelStreamParser parser)
     {
         this.parser = parser;
-        this.xwikiSyntaxPrintRendererFactory = xwikiSyntaxPrintRendererFactory;
     }
 
     @Override
@@ -93,12 +102,8 @@ public class XWikiReferenceTagHandler extends ReferenceTagHandler implements XWi
             WikiParameter ref = context.getParams().getParameter("href");
 
             if (ref != null) {
-                DefaultWikiPrinter printer = new DefaultWikiPrinter();
-
-                PrintRenderer linkLabelRenderer = this.xwikiSyntaxPrintRendererFactory.createRenderer(printer);
-
                 XWikiGeneratorListener xwikiListener =
-                    this.parser.createXWikiGeneratorListener(linkLabelRenderer, null);
+                    this.parser.createXWikiGeneratorListener(new XDOMGeneratorListener(), null);
                 context.getTagStack().pushScannerContext(new WikiScannerContext(xwikiListener));
 
                 // Ensure we simulate a new document being parsed
@@ -142,17 +147,53 @@ public class XWikiReferenceTagHandler extends ReferenceTagHandler implements XWi
                 WikiScannerContext scannerContext = context.getTagStack().popScannerContext();
 
                 XWikiGeneratorListener xwikiListener = (XWikiGeneratorListener) scannerContext.getfListener();
-                PrintRenderer linkLabelRenderer = (PrintRenderer) xwikiListener.getListener();
+                XDOMGeneratorListener linkLabelRenderer = (XDOMGeneratorListener) xwikiListener.getListener();
 
-                String label = linkLabelRenderer.getPrinter().toString();
+                XDOM label = linkLabelRenderer.getXDOM();
 
-                WikiReference reference =
-                    new WikiReference(ref.getValue(), label, removeMeaningfulParameters(parameters));
+                ResourceReference resourceReference = computeResourceReference(ref.getValue());
+
+                XWikiWikiReference reference =
+                    new XWikiWikiReference(resourceReference, label, removeMeaningfulParameters(parameters), false);
 
                 context.getScannerContext().onReference(reference);
             }
         } else {
             super.end(context);
         }
+    }
+
+    /**
+     * Recognize the passed reference and figure out what type of link it should be:
+     * <ul>
+     *   <li>UC1: the reference points to a valid URL, we return a reference of type "url",
+     *       e.g. {@code http://server/path/reference#anchor}</li>
+     *   <li>UC2: the reference is a mailto: link, we return a reference of type "mailto",
+     *       e.g., {@code mailto:user@example.com}</li>
+     *   <li>UC3: the reference is not a valid URL, we return a reference of type "path",
+     *       e.g. {@code path/reference#anchor}</li>
+     * </ul>
+     *
+     * @param rawReference the full reference (e.g. "/some/path/something#other")
+     * @return the properly typed {@link ResourceReference} matching the use cases
+     */
+    private ResourceReference computeResourceReference(String rawReference)
+    {
+        ResourceReference reference;
+
+        // Do we have a valid URL?
+        Matcher matcher = URL_SCHEME_PATTERN.matcher(rawReference);
+        if (matcher.lookingAt()) {
+            // We have UC1
+            reference = new ResourceReference(rawReference, ResourceType.URL);
+        } else if (rawReference.startsWith(MAILTO_PREFIX)) {
+            // We have UC2
+            reference = new ResourceReference(rawReference.substring(MAILTO_PREFIX.length()), ResourceType.MAILTO);
+        } else {
+            // We have UC3
+            reference = new ResourceReference(rawReference, ResourceType.PATH);
+        }
+
+        return reference;
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiReferenceTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiReferenceTagHandler.java
@@ -59,7 +59,8 @@ public class XWikiReferenceTagHandler extends ReferenceTagHandler implements XWi
     private WikiModelStreamParser parser;
 
     /**
-     * @since 2.2.5
+     * @param parser the XHTML parser, used for the label
+     * @since 14.10RC1
      * @todo Remove the need to pass a Parser when WikiModel implements support for wiki syntax in links. See
      *       http://code.google.com/p/wikimodel/issues/detail?id=87
      */

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
@@ -49,8 +49,6 @@ public class XWikiWikiReference extends WikiReference
      * @param linkParameters the parameters of the link
      * @param freeStanding if the link is freestanding
      * @since 14.10RC1
-     * @since 14.4.7
-     * @since 13.10.11
      */
     public XWikiWikiReference(ResourceReference reference, XDOM label, WikiParameters linkParameters,
         boolean freeStanding)
@@ -64,8 +62,6 @@ public class XWikiWikiReference extends WikiReference
     /**
      * @return the parsed label's XDOM
      * @since 14.10RC1
-     * @since 14.4.7
-     * @since 13.10.11
      */
     public XDOM getLabelXDOM()
     {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
@@ -21,6 +21,7 @@ package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.wikimodel.WikiParameters;
 import org.xwiki.rendering.wikimodel.WikiReference;
@@ -38,12 +39,31 @@ public class XWikiWikiReference extends WikiReference
 
     private boolean freeStanding;
 
-    public XWikiWikiReference(ResourceReference reference, String label, WikiParameters linkParameters,
+    private final XDOM labelXDOM;
+
+    /**
+     * Construct a new wiki reference.
+     *
+     * @param reference the reference the link points to
+     * @param label the already parsed label content
+     * @param linkParameters the parameters of the link
+     * @param freeStanding if the link is freestanding
+     */
+    public XWikiWikiReference(ResourceReference reference, XDOM label, WikiParameters linkParameters,
         boolean freeStanding)
     {
-        super(reference.getReference(), label, linkParameters);
+        super(reference.getReference(), null, linkParameters);
         this.reference = reference;
         this.freeStanding = freeStanding;
+        this.labelXDOM = label;
+    }
+
+    /**
+     * @return the parsed label's XDOM
+     */
+    public XDOM getLabelXDOM()
+    {
+        return this.labelXDOM;
     }
 
     public boolean isFreeStanding()
@@ -75,6 +95,7 @@ public class XWikiWikiReference extends WikiReference
         builder.appendSuper(super.equals(obj));
         builder.append(this.reference, ((XWikiWikiReference) obj).reference);
         builder.append(this.freeStanding, ((XWikiWikiReference) obj).freeStanding);
+        builder.append(this.labelXDOM, ((XWikiWikiReference) obj).labelXDOM);
 
         return builder.isEquals();
     }
@@ -87,6 +108,7 @@ public class XWikiWikiReference extends WikiReference
         builder.appendSuper(super.hashCode());
         builder.append(reference);
         builder.append(freeStanding);
+        builder.append(this.labelXDOM);
 
         return builder.toHashCode();
     }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java
@@ -48,6 +48,9 @@ public class XWikiWikiReference extends WikiReference
      * @param label the already parsed label content
      * @param linkParameters the parameters of the link
      * @param freeStanding if the link is freestanding
+     * @since 14.10RC1
+     * @since 14.4.7
+     * @since 13.10.11
      */
     public XWikiWikiReference(ResourceReference reference, XDOM label, WikiParameters linkParameters,
         boolean freeStanding)
@@ -60,6 +63,9 @@ public class XWikiWikiReference extends WikiReference
 
     /**
      * @return the parsed label's XDOM
+     * @since 14.10RC1
+     * @since 14.4.7
+     * @since 13.10.11
      */
     public XDOM getLabelXDOM()
     {

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/main/java/org/xwiki/rendering/internal/parser/xhtml5/XHTML5Parser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/main/java/org/xwiki/rendering/internal/parser/xhtml5/XHTML5Parser.java
@@ -27,9 +27,6 @@ import javax.inject.Named;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XWikiFigcaptionTagHandler;
-import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XWikiFigureTagHandler;
-import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XHTML5SpanTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiCommentHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiDivTagHandler;
@@ -37,9 +34,11 @@ import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeaderTagHandler
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiImageTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiTableDataTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XHTML5SpanTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XWikiFigcaptionTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml5.wikimodel.XWikiFigureTagHandler;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.parser.ResourceReferenceParser;
-import org.xwiki.rendering.renderer.PrintRendererFactory;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.wikimodel.IWikiParser;
 import org.xwiki.rendering.wikimodel.xhtml.XhtmlParser;
@@ -60,10 +59,6 @@ import static org.xwiki.rendering.internal.xhtml5.XHTML5SyntaxProvider.XHTML_5;
 @Unstable
 public class XHTML5Parser extends XHTMLParser
 {
-    @Inject
-    @Named("xdom+xml/current")
-    private PrintRendererFactory xmlRenderer;
-
     @Inject
     private ComponentManager componentManager;
 
@@ -103,7 +98,7 @@ public class XHTML5Parser extends XHTMLParser
         handlers.put("h4", handler);
         handlers.put("h5", handler);
         handlers.put("h6", handler);
-        handlers.put("a", new XWikiReferenceTagHandler(this, this.xmlRenderer));
+        handlers.put("a", new XWikiReferenceTagHandler(this));
         handlers.put("img", new XWikiImageTagHandler());
         handlers.put("span", new XHTML5SpanTagHandler(this.componentManager, this));
         // Change the class value indicating that the division is an embedded document. We do this in order to be
@@ -118,8 +113,8 @@ public class XHTML5Parser extends XHTMLParser
 
         XhtmlParser parser = new XhtmlParser();
         parser.setExtraHandlers(handlers);
-        parser.setCommentHandler(new XWikiCommentHandler(this.componentManager, this, this.xmlRenderer,
-            this.xhtmlMarkerResourceReferenceParser));
+        parser.setCommentHandler(
+            new XWikiCommentHandler(this.componentManager, this, this.xhtmlMarkerResourceReferenceParser));
 
         // Construct our own XML filter chain since we want to use our own Comment filter.
         try {


### PR DESCRIPTION
* Pass the label via an XDOM instance instead of rendering/parsing to xdom+xml syntax.
* Move the reference type detection into the XWikiReferenceTagHandler to simplify XHTMLXWikiGeneratorListener.

I'm not super happy with the new workaround but I think it's better than the old one, avoids the dependency on another syntax and shouldn't cause any breakages as we're (mostly) still doing the same. The better design would be to introduce begin/end methods for references but then we would need (probably) major changes in WikiModel to properly support everything that currently works like having independent styling in link labels.