### PR TITLE
XRENDERING-702: The content macro breaks WYSIWYG editing

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/pom.xml
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/pom.xml
@@ -43,5 +43,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-syntax-annotatedhtml5</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/test/resources/macrocontent4.test
@@ -1,0 +1,31 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Add HTML 5.0 content in XWiki Syntax 2.1 content. Test conversion from and to annotated HTML.
+.#-----------------------------------------------------
+{{content syntax="html/5.0"}}
+<p>test</p><p>test2</p>
+{{/content}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [content] [syntax=html/5.0] [<p>test</p><p>test2</p>]
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>][syntax]=[HTML 5.0]]
+beginParagraph
+onWord [test]
+endParagraph
+beginParagraph
+onWord [test2]
+endParagraph
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>][syntax]=[HTML 5.0]]
+endMacroMarkerStandalone [content] [syntax=html/5.0] [<p>test</p><p>test2</p>]
+endDocument
+.#-----------------------------------------------------
+.expect|annotatedhtml/5.0
+.#-----------------------------------------------------
+<!--startmacro:content|-|syntax="html/5.0"|-|<p>test</p><p>test2</p>--><div data-xwiki-syntax="html/5.0" data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p>test</p><p>test2</p></div><!--stopmacro-->
+.#-----------------------------------------------------
+.input|html/5.0
+.#-----------------------------------------------------
+<!--startmacro:content|-|syntax="html/5.0"|-|<p>test</p><p>test2</p>--><div data-xwiki-syntax="html/5.0" data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p>test</p><p>test2</p></div><!--stopmacro-->

--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/renderers/annotatedhtml5/HTMLMacroAnnotatedHTML5Renderer.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/renderers/annotatedhtml5/HTMLMacroAnnotatedHTML5Renderer.java
@@ -27,6 +27,7 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.internal.macro.html.AbstractHTMLMacroRenderer;
 import org.xwiki.rendering.internal.renderer.html5.AnnotatedHTML5ChainingRenderer;
+import org.xwiki.rendering.internal.renderer.xhtml.XHTMLMetaDataRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.renderer.AbstractChainingPrintRenderer;
@@ -61,12 +62,15 @@ public class HTMLMacroAnnotatedHTML5Renderer extends AbstractHTMLMacroRenderer
     private XHTMLImageRenderer imageRenderer;
 
     @Inject
+    private XHTMLMetaDataRenderer metaDataRenderer;
+
+    @Inject
     private HTMLElementSanitizer htmlElementSanitizer;
 
     @Override
     protected AbstractChainingPrintRenderer getSyntaxRenderer()
     {
-        return new AnnotatedHTML5ChainingRenderer(this.linkRenderer, this.imageRenderer, this.htmlElementSanitizer,
-            getListenerChain());
+        return new AnnotatedHTML5ChainingRenderer(this.linkRenderer, this.imageRenderer, this.metaDataRenderer,
+            this.htmlElementSanitizer, getListenerChain());
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/renderers/annotatedxhtml/HTMLMacroAnnotatedXHTMLRenderer.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/renderers/annotatedxhtml/HTMLMacroAnnotatedXHTMLRenderer.java
@@ -27,6 +27,7 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.rendering.internal.macro.html.AbstractHTMLMacroRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.AnnotatedXHTMLChainingRenderer;
+import org.xwiki.rendering.internal.renderer.xhtml.XHTMLMetaDataRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.renderer.AbstractChainingPrintRenderer;
@@ -65,10 +66,13 @@ public class HTMLMacroAnnotatedXHTMLRenderer extends AbstractHTMLMacroRenderer
     @Inject
     private HTMLElementSanitizer htmlElementSanitizer;
 
+    @Inject
+    private XHTMLMetaDataRenderer metaDataRenderer;
+
     @Override
     protected AbstractChainingPrintRenderer getSyntaxRenderer()
     {
-        return new AnnotatedXHTMLChainingRenderer(this.linkRenderer, this.imageRenderer, this.htmlElementSanitizer,
-            getListenerChain());
+        return new AnnotatedXHTMLChainingRenderer(this.linkRenderer, this.imageRenderer, this.metaDataRenderer,
+            this.htmlElementSanitizer, getListenerChain());
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5ChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5ChainingRenderer.java
@@ -56,17 +56,19 @@ public class AnnotatedHTML5ChainingRenderer extends HTML5ChainingRenderer
      * @param imageRenderer the object to render image events into XHTML. This is done so that it's pluggable because
      *            image rendering depends on how the underlying system wants to handle it. For example for XWiki we
      *            check if the image exists as a document attachments, we get its URL, etc.
+     * @param metadataRenderer the object to render metadata events into XHTML.
      * @param htmlElementSanitizer the HTML element sanitizer to use
      * @param listenerChain the chain of listener filters used to compute various states
      */
     public AnnotatedHTML5ChainingRenderer(XHTMLLinkRenderer linkRenderer,
-            XHTMLImageRenderer imageRenderer, HTMLElementSanitizer htmlElementSanitizer, ListenerChain listenerChain)
+        XHTMLImageRenderer imageRenderer, XHTMLMetaDataRenderer metadataRenderer,
+        HTMLElementSanitizer htmlElementSanitizer, ListenerChain listenerChain)
     {
         super(linkRenderer, imageRenderer, htmlElementSanitizer, listenerChain);
 
         this.macroRenderer = new XHTMLMacroRenderer();
 
-        this.metaDataRenderer = new XHTMLMetaDataRenderer();
+        this.metaDataRenderer = metadataRenderer;
     }
 
     @Override

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5Renderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedhtml5/src/main/java/org/xwiki/rendering/internal/renderer/html5/AnnotatedHTML5Renderer.java
@@ -27,6 +27,7 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.component.phase.Initializable;
 import org.xwiki.component.phase.InitializationException;
+import org.xwiki.rendering.internal.renderer.xhtml.XHTMLMetaDataRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.image.XHTMLImageRenderer;
 import org.xwiki.rendering.internal.renderer.xhtml.link.XHTMLLinkRenderer;
 import org.xwiki.rendering.listener.chaining.BlockStateChainingListener;
@@ -69,6 +70,9 @@ public class AnnotatedHTML5Renderer extends AbstractChainingPrintRenderer implem
     private XHTMLImageRenderer imageRenderer;
 
     @Inject
+    private XHTMLMetaDataRenderer metaDataRenderer;
+
+    @Inject
     private HTMLElementSanitizer htmlElementSanitizer;
 
     @Override
@@ -84,6 +88,6 @@ public class AnnotatedHTML5Renderer extends AbstractChainingPrintRenderer implem
         chain.addListener(new EmptyBlockChainingListener(chain));
         chain.addListener(new MetaDataStateChainingListener(chain));
         chain.addListener(new AnnotatedHTML5ChainingRenderer(this.linkRenderer, this.imageRenderer,
-            this.htmlElementSanitizer, chain));
+            this.metaDataRenderer, this.htmlElementSanitizer, chain));
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLChainingRenderer.java
@@ -53,17 +53,19 @@ public class AnnotatedXHTMLChainingRenderer extends XHTMLChainingRenderer
      * @param imageRenderer the object to render image events into XHTML. This is done so that it's pluggable because
      *            image rendering depends on how the underlying system wants to handle it. For example for XWiki we
      *            check if the image exists as a document attachments, we get its URL, etc.
+     * @param metadataRenderer the object to render metadata events into XHTML.
      * @param htmlElementSanitizer the sanitizer to use for sanitizing HTML elements and attributes
      * @param listenerChain the chain of listener filters used to compute various states
      */
     public AnnotatedXHTMLChainingRenderer(XHTMLLinkRenderer linkRenderer,
-        XHTMLImageRenderer imageRenderer, HTMLElementSanitizer htmlElementSanitizer, ListenerChain listenerChain)
+        XHTMLImageRenderer imageRenderer, XHTMLMetaDataRenderer metadataRenderer,
+        HTMLElementSanitizer htmlElementSanitizer, ListenerChain listenerChain)
     {
         super(linkRenderer, imageRenderer, htmlElementSanitizer, listenerChain);
 
         this.macroRenderer = new XHTMLMacroRenderer();
 
-        this.metaDataRenderer = new XHTMLMetaDataRenderer();
+        this.metaDataRenderer = metadataRenderer;
     }
 
     @Override

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/AnnotatedXHTMLRenderer.java
@@ -69,6 +69,9 @@ public class AnnotatedXHTMLRenderer extends AbstractChainingPrintRenderer implem
     private XHTMLImageRenderer imageRenderer;
 
     @Inject
+    private XHTMLMetaDataRenderer metaDataRenderer;
+
+    @Inject
     private HTMLElementSanitizer htmlElementSanitizer;
 
     @Override
@@ -84,6 +87,6 @@ public class AnnotatedXHTMLRenderer extends AbstractChainingPrintRenderer implem
         chain.addListener(new EmptyBlockChainingListener(chain));
         chain.addListener(new MetaDataStateChainingListener(chain));
         chain.addListener(new AnnotatedXHTMLChainingRenderer(this.linkRenderer, this.imageRenderer,
-            this.htmlElementSanitizer, chain));
+            this.metaDataRenderer, this.htmlElementSanitizer, chain));
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/XHTMLMetaDataRenderer.java
@@ -22,6 +22,11 @@ package org.xwiki.rendering.internal.renderer.xhtml;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.properties.ConverterManager;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
@@ -32,8 +37,13 @@ import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
  * @version $Id$
  * @since 14.0RC1
  */
+@Component(roles = XHTMLMetaDataRenderer.class)
+@Singleton
 public class XHTMLMetaDataRenderer
 {
+    @Inject
+    private ConverterManager converterManager;
+
     /**
      * @return a span element if we are inside an inline macro. Else a div.
      */
@@ -58,8 +68,8 @@ public class XHTMLMetaDataRenderer
         Map<String, String> attributes = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> metadataPair : metaData.getMetaData().entrySet()) {
-            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadataPair.getKey(),
-                metadataPair.getValue().toString());
+            String value = this.converterManager.convert(String.class, metadataPair.getValue());
+            attributes.put(XHTMLXWikiGeneratorListener.METADATA_ATTRIBUTE_PREFIX + metadataPair.getKey(), value);
         }
 
         attributes.put("class", XHTMLXWikiGeneratorListener.METADATA_CONTAINER_CLASS);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/resources/META-INF/components.txt
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-annotatedxhtml/src/main/resources/META-INF/components.txt
@@ -1,6 +1,7 @@
 org.xwiki.rendering.internal.renderer.xhtml.AnnotatedXHTMLBlockRenderer
 org.xwiki.rendering.internal.renderer.xhtml.AnnotatedXHTMLRendererFactory
 org.xwiki.rendering.internal.renderer.xhtml.AnnotatedXHTMLRenderer
+org.xwiki.rendering.internal.renderer.xhtml.XHTMLMetaDataRenderer
 org.xwiki.rendering.internal.renderer.xhtml.image.AnnotatedXHTMLImageRenderer
 org.xwiki.rendering.internal.renderer.xhtml.link.AnnotatedXHTMLLinkRenderer
 org.xwiki.rendering.internal.xhtml.AnnotatedXHTML10SyntaxProvider

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
@@ -19,9 +19,8 @@
  */
 package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.util.ReflectionUtils;
@@ -53,12 +52,11 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
 {
     private static final String WIKI_CONTENT_TYPE = ReflectionUtils.serializeType(Block.LIST_BLOCK_TYPE);
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiMacroHandler.class);
+
     private ComponentManager componentManager;
 
     private XHTMLParser parser;
-
-    @Inject
-    private Logger logger;
 
     /**
      * Default constructor for XWikiMacroHandler.
@@ -87,7 +85,7 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
                 RenderingContext renderingContext = this.componentManager.getInstance(RenderingContext.class);
                 syntax = renderingContext.getTargetSyntax();
             } catch (ComponentLookupException e) {
-                this.logger.error("Error while retrieving the rendering context", e);
+                LOGGER.error("Error while retrieving the rendering context", e);
             }
             if (syntax == null) {
                 syntax = this.parser.getSyntax();
@@ -162,7 +160,7 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
                         context.getTagStack().getScannerContext().beginDocument();
                     }
                 } catch (ComponentLookupException e) {
-                    this.logger.error("Error while getting the appropriate renderer for syntax [{}]",
+                    LOGGER.error("Error while getting the appropriate renderer for syntax [{}]",
                         currentSyntaxParameter, e);
                 }
             }


### PR DESCRIPTION
* Use ConverterManager to serialize metadata to strings.
* Fix wrong inject in non-component.
* Add integration test for verifying that parsing from HTML actually works.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-702