### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
@@ -931,12 +931,12 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
         this.previousEvent = Event.MACRO;
     }
 
-    private static class ListState
+    private static final class ListState
     {
         public int listItemIndex = -1;
     }
 
-    private static class DefinitionListState
+    private static final class DefinitionListState
     {
         public int definitionListItemIndex = -1;
     }

--- a/xwiki-rendering-api/src/test/java/org/xwiki/rendering/internal/syntax/SyntaxRegistryListenerTest.java
+++ b/xwiki-rendering-api/src/test/java/org/xwiki/rendering/internal/syntax/SyntaxRegistryListenerTest.java
@@ -61,7 +61,7 @@ class SyntaxRegistryListenerTest
      * CM initialization. Note that the MySyntaxProvider component is registered in the CM during the initial CM
      * initialization and this allows us to test the 2 use cases and verify they both work.
      */
-    private class MyExtensionSyntaxProvider implements Provider<List<Syntax>>
+    private final class MyExtensionSyntaxProvider implements Provider<List<Syntax>>
     {
         @Override
         public List<Syntax> get()

--- a/xwiki-rendering-api/src/test/java/org/xwiki/rendering/listener/chaining/AbstractChainingListenerTest.java
+++ b/xwiki-rendering-api/src/test/java/org/xwiki/rendering/listener/chaining/AbstractChainingListenerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 class AbstractChainingListenerTest
 {
-    private static class AbstractChild extends AbstractChainingPrintRenderer
+    private static final class AbstractChild extends AbstractChainingPrintRenderer
     {
         boolean called;
 
@@ -55,7 +55,7 @@ class AbstractChainingListenerTest
         }
     }
 
-    private static class Child extends AbstractChainingListener
+    private static final class Child extends AbstractChainingListener
     {
         boolean called;
 
@@ -66,12 +66,12 @@ class AbstractChainingListenerTest
         }
     }
 
-    private static class Child2 extends AbstractChild
+    private static final class Child2 extends AbstractChild
     {
 
     }
 
-    private static class ChildWithBothBeginMethods extends AbstractChild
+    private static final class ChildWithBothBeginMethods extends AbstractChild
     {
         boolean calledWithoutParameter;
         boolean calledWithParameter;
@@ -93,7 +93,7 @@ class AbstractChainingListenerTest
         }
     }
 
-    private static class Child3 extends AbstractChainingListener
+    private static final class Child3 extends AbstractChainingListener
     {
         boolean called;
 
@@ -104,11 +104,11 @@ class AbstractChainingListenerTest
         }
     }
 
-    private static class DummyListener extends AbstractChainingListener
+    private static final class DummyListener extends AbstractChainingListener
     {
     }
 
-    private static class EndListItemChild extends AbstractChainingListener
+    private static final class EndListItemChild extends AbstractChainingListener
     {
         boolean called;
 

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/WikiModelParserUtils.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-wikimodel/src/main/java/org/xwiki/rendering/internal/parser/wikimodel/WikiModelParserUtils.java
@@ -42,7 +42,7 @@ public class WikiModelParserUtils extends ParserUtils
         parseInline(parser, content, listener, null, false);
     }
 
-    private class PrefixIgnoredInlineFilterListener extends InlineFilterListener
+    private final class PrefixIgnoredInlineFilterListener extends InlineFilterListener
     {
         private boolean foundWord;
 

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/impl/WikiScannerContext.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/impl/WikiScannerContext.java
@@ -41,7 +41,7 @@ public class WikiScannerContext implements IWikiScannerContext
 
     protected final Deque<IWikiScannerContext> fStack = new ArrayDeque<IWikiScannerContext>();
 
-    private class DefaultSectionListener extends SectionListener<WikiParameters>
+    private final class DefaultSectionListener extends SectionListener<WikiParameters>
     {
         @Override
         public void beginDocument(IPos<WikiParameters> pos)

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xwiki/xwiki20/XWikiSerializer2.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xwiki/xwiki20/XWikiSerializer2.java
@@ -623,7 +623,7 @@ public class XWikiSerializer2 extends PrintTextListener
     /**
      * Workaround to put a caption in front of a table.
      */
-    private static class Table
+    private static final class Table
     {
         private StringBuilder text = new StringBuilder();
 


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.