### PR TITLE
XRENDERING-707: The toc macro use the name of the page for empty headers entries

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
@@ -54,8 +54,8 @@ public class TocBlockFilter extends PlainTextBlockFilter
     {
         List<Block> children = headerBlock.clone(this).getChildren();
         if (children.isEmpty()) {
-            // In case of empty header, explicitly assign an empty label. Otherwise, the toc entry is generated with 
-            // the name of the page.
+            // If the header is empty, explicitly assign a single space. Otherwise, the toc entry is created with the
+            // name of the page.
             children = List.of(new SpaceBlock());
         }
         return children;

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.PlainTextBlockFilter;
+import org.xwiki.rendering.block.WordBlock;
 import org.xwiki.rendering.parser.Parser;
 import org.xwiki.rendering.renderer.reference.link.LinkLabelGenerator;
 
@@ -51,6 +52,12 @@ public class TocBlockFilter extends PlainTextBlockFilter
      */
     public List<Block> generateLabel(HeaderBlock headerBlock)
     {
-        return headerBlock.clone(this).getChildren();
+        List<Block> children = headerBlock.clone(this).getChildren();
+        if (children.isEmpty()) {
+            // In case of empty header, explicitly assign an empty label. Otherwise, the toc entry is generated with 
+            // the name of the page.
+            children = List.of(new WordBlock(""));
+        }
+        return children;
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/TocBlockFilter.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.PlainTextBlockFilter;
-import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.SpaceBlock;
 import org.xwiki.rendering.parser.Parser;
 import org.xwiki.rendering.renderer.reference.link.LinkLabelGenerator;
 
@@ -56,7 +56,7 @@ public class TocBlockFilter extends PlainTextBlockFilter
         if (children.isEmpty()) {
             // In case of empty header, explicitly assign an empty label. Otherwise, the toc entry is generated with 
             // the name of the page.
-            children = List.of(new WordBlock(""));
+            children = List.of(new SpaceBlock());
         }
         return children;
     }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc11.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc11.test
@@ -12,6 +12,7 @@ beginMacroMarkerStandalone [toc] [reference=somereference]
 beginList [BULLETED] [[class]=[wikitoc]]
 beginListItem
 beginLink [Typed = [true] Type = [doc] Reference = [somereference]] [false]
+onWord []
 endLink [Typed = [true] Type = [doc] Reference = [somereference]] [false]
 endListItem
 endList [BULLETED] [[class]=[wikitoc]]

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc11.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc11.test
@@ -12,7 +12,7 @@ beginMacroMarkerStandalone [toc] [reference=somereference]
 beginList [BULLETED] [[class]=[wikitoc]]
 beginListItem
 beginLink [Typed = [true] Type = [doc] Reference = [somereference]] [false]
-onWord []
+onSpace
 endLink [Typed = [true] Type = [doc] Reference = [somereference]] [false]
 endListItem
 endList [BULLETED] [[class]=[wikitoc]]

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
@@ -16,12 +16,12 @@ beginMacroMarkerStandalone [toc] []
 beginList [BULLETED] [[class]=[wikitoc]]
 beginListItem
 beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H]]] [false]
-onWord []
+onSpace
 endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H]]] [false]
 beginList [BULLETED]
 beginListItem
 beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H-1]]] [false]
-onWord []
+onSpace
 endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H-1]]] [false]
 endListItem
 endList [BULLETED]
@@ -40,4 +40,4 @@ endDocument
 .#-----------------------------------------------------
 .expect|xhtml/1.0
 .#-----------------------------------------------------
-<ul class="wikitoc"><li><span class="wikilink"><a href="#H"></a></span><ul><li><span class="wikilink"><a href="#H-1"></a></span></li></ul></li></ul><h1 id="H" class="wikigeneratedid"><span></span></h1><h2 id="H-1" class="wikigeneratedid"><span></span></h2>
+<ul class="wikitoc"><li><span class="wikilink"><a href="#H">&nbsp;</a></span><ul><li><span class="wikilink"><a href="#H-1">&nbsp;</a></span></li></ul></li></ul><h1 id="H" class="wikigeneratedid"><span></span></h1><h2 id="H-1" class="wikigeneratedid"><span></span></h2>

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
@@ -1,7 +1,7 @@
 .runTransformations
 .#-----------------------------------------------------
 .input|xwiki/2.1
-.# Verify that a toc containing empty header generates empty entries.
+.# Verify that a toc containing empty header generates entries containing a single space.
 .#-----------------------------------------------------
 {{toc/}}
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/test/resources/wikimodel/macrotoc14.test
@@ -1,0 +1,43 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Verify that a toc containing empty header generates empty entries.
+.#-----------------------------------------------------
+{{toc/}}
+
+=   =
+
+==   ==
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [toc] []
+beginList [BULLETED] [[class]=[wikitoc]]
+beginListItem
+beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H]]] [false]
+onWord []
+endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H]]] [false]
+beginList [BULLETED]
+beginListItem
+beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H-1]]] [false]
+onWord []
+endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [H-1]]] [false]
+endListItem
+endList [BULLETED]
+endListItem
+endList [BULLETED] [[class]=[wikitoc]]
+endMacroMarkerStandalone [toc] []
+beginSection
+beginHeader [1, H]
+endHeader [1, H]
+beginSection
+beginHeader [2, H-1]
+endHeader [2, H-1]
+endSection
+endSection
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<ul class="wikitoc"><li><span class="wikilink"><a href="#H"></a></span><ul><li><span class="wikilink"><a href="#H-1"></a></span></li></ul></li></ul><h1 id="H" class="wikigeneratedid"><span></span></h1><h2 id="H-1" class="wikigeneratedid"><span></span></h2>


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XRENDERING-707