### PR TITLE
XRENDERING-721: Content of script tags should be ignored to avoid additional content being saved

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
@@ -38,7 +38,7 @@ import org.xwiki.rendering.internal.parser.wikimodel.XWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiCommentHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiDivTagHandler;
-import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeadTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiIgnoredTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeaderTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiImageTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
@@ -57,6 +57,7 @@ import org.xwiki.xml.XMLReaderFactory;
 
 import static org.xwiki.rendering.internal.xhtml.XHTML10SyntaxProvider.XHTML_1_0;
 import static org.xwiki.xml.html.HTMLConstants.TAG_HEAD;
+import static org.xwiki.xml.html.HTMLConstants.TAG_SCRIPT;
 
 /**
  * Parses XHTML and generate a {@link org.xwiki.rendering.block.XDOM} object.
@@ -136,7 +137,8 @@ public class XHTMLParser extends AbstractWikiModelParser
         // another implementation we won't be tied to WikiModel.
         handlers.put("div", new XWikiDivTagHandler("xwiki-document", this.componentManager, this));
         handlers.put("th", new XWikiTableDataTagHandler());
-        handlers.put(TAG_HEAD, new XWikiHeadTagHandler());
+        handlers.put(TAG_HEAD, new XWikiIgnoredTagHandler(TAG_HEAD));
+        handlers.put(TAG_SCRIPT, new XWikiIgnoredTagHandler(TAG_SCRIPT));
 
         XhtmlParser parser = new XhtmlParser();
         parser.setExtraHandlers(handlers);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/XHTMLParser.java
@@ -38,6 +38,7 @@ import org.xwiki.rendering.internal.parser.wikimodel.XWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XHTMLXWikiGeneratorListener;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiCommentHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiDivTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeadTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeaderTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiImageTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
@@ -55,6 +56,7 @@ import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
 import org.xwiki.xml.XMLReaderFactory;
 
 import static org.xwiki.rendering.internal.xhtml.XHTML10SyntaxProvider.XHTML_1_0;
+import static org.xwiki.xml.html.HTMLConstants.TAG_HEAD;
 
 /**
  * Parses XHTML and generate a {@link org.xwiki.rendering.block.XDOM} object.
@@ -134,6 +136,7 @@ public class XHTMLParser extends AbstractWikiModelParser
         // another implementation we won't be tied to WikiModel.
         handlers.put("div", new XWikiDivTagHandler("xwiki-document", this.componentManager, this));
         handlers.put("th", new XWikiTableDataTagHandler());
+        handlers.put(TAG_HEAD, new XWikiHeadTagHandler());
 
         XhtmlParser parser = new XhtmlParser();
         parser.setExtraHandlers(handlers);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiHeadTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiHeadTagHandler.java
@@ -1,0 +1,62 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
+
+import java.util.Objects;
+
+import org.xwiki.rendering.wikimodel.xhtml.handler.TagHandler;
+import org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
+
+import static org.xwiki.xml.html.HTMLConstants.TAG_HEAD;
+
+/**
+ * Handler for the head tag. Ignore all the content of the element.
+ *
+ * @version $Id$
+ * @since 15.6RC1
+ * @since 15.5.1
+ * @since 14.10.14
+ */
+public class XWikiHeadTagHandler extends TagHandler
+{
+    /**
+     * Default constructor.
+     */
+    public XWikiHeadTagHandler()
+    {
+        super(false);
+    }
+
+    @Override
+    protected void begin(TagContext context)
+    {
+        TagStack tagStack = context.getTagStack();
+        tagStack.pushIgnoreElementRule(new IgnoreElementRule(ignoreElementRule -> {
+            TagContext tagContext = ignoreElementRule.getTagContext();
+            // Pops itself off the stack when the head element ends.
+            if (Objects.equals(tagContext.getName(), TAG_HEAD)) {
+                tagContext.getTagStack().popIgnoreElementRule();
+            }
+            return false;
+        }, true));
+    }
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiIgnoredTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiIgnoredTagHandler.java
@@ -26,24 +26,27 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.IgnoreElementRule;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
 
-import static org.xwiki.xml.html.HTMLConstants.TAG_HEAD;
-
 /**
- * Handler for the head tag. Ignore all the content of the element.
+ * Handle any tag for which the content can be ignored during parsing.
  *
  * @version $Id$
  * @since 15.6RC1
  * @since 15.5.1
  * @since 14.10.14
  */
-public class XWikiHeadTagHandler extends TagHandler
+public class XWikiIgnoredTagHandler extends TagHandler
 {
+    private final String tag;
+
     /**
      * Default constructor.
+     *
+     * @param tag name of the tag to ignore
      */
-    public XWikiHeadTagHandler()
+    public XWikiIgnoredTagHandler(String tag)
     {
         super(false);
+        this.tag = tag;
     }
 
     @Override
@@ -53,7 +56,7 @@ public class XWikiHeadTagHandler extends TagHandler
         tagStack.pushIgnoreElementRule(new IgnoreElementRule(ignoreElementRule -> {
             TagContext tagContext = ignoreElementRule.getTagContext();
             // Pops itself off the stack when the head element ends.
-            if (Objects.equals(tagContext.getName(), TAG_HEAD)) {
+            if (Objects.equals(tagContext.getName(), this.tag)) {
                 tagContext.getTagStack().popIgnoreElementRule();
             }
             return false;

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiIgnoredTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiIgnoredTagHandler.java
@@ -27,7 +27,7 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagStack;
 
 /**
- * Handle any tag for which the content can be ignored during parsing.
+ * Handle any tag for which the content should be ignored during parsing.
  *
  * @version $Id$
  * @since 15.6RC1

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/head/head1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/head/head1.test
@@ -1,0 +1,22 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <script id="numbered-headings-config" type="application/json">
+      {
+        "isActivated": false,
+        "isActivatedOnParent": false
+      }
+    </script>
+  </head>
+  <body id="body" class="skin-flamingo viewbody main wiki-xwikispace-XWiki">
+  mybody
+  </body>
+</html>
+.#-----------------------------------------------------
+.expect|xwiki/2.1
+.#-----------------------------------------------------
+mybody

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/head/head1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/head/head1.test
@@ -1,5 +1,6 @@
 .#-----------------------------------------------------
 .input|xhtml/1.0
+.# Verify that the content of the head element is ignored.
 .#-----------------------------------------------------
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
@@ -13,7 +14,7 @@
     </script>
   </head>
   <body id="body" class="skin-flamingo viewbody main wiki-xwikispace-XWiki">
-  mybody
+    mybody
   </body>
 </html>
 .#-----------------------------------------------------

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/script/script1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/script/script1.test
@@ -1,0 +1,22 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body id="body" class="skin-flamingo viewbody main wiki-xwikispace-XWiki">
+    <script id="numbered-headings-config" type="application/json">
+      {
+        "isActivated": false,
+        "isActivatedOnParent": false
+      }
+    </script>
+  mybody
+  </body>
+</html>
+.#-----------------------------------------------------
+.expect|xwiki/2.1
+.#-----------------------------------------------------
+mybody

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/pom.xml
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/pom.xml
@@ -48,6 +48,12 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-syntax-xwiki21</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
       <artifactId>xwiki-rendering-syntax-xhtml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/main/java/org/xwiki/rendering/internal/parser/xhtml5/XHTML5Parser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/main/java/org/xwiki/rendering/internal/parser/xhtml5/XHTML5Parser.java
@@ -30,6 +30,7 @@ import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiCommentHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiDivTagHandler;
+import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiIgnoredTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiHeaderTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiImageTagHandler;
 import org.xwiki.rendering.internal.parser.xhtml.wikimodel.XWikiReferenceTagHandler;
@@ -47,6 +48,8 @@ import org.xwiki.stability.Unstable;
 import org.xwiki.xml.XMLReaderFactory;
 
 import static org.xwiki.rendering.internal.xhtml5.XHTML5SyntaxProvider.XHTML_5;
+import static org.xwiki.xml.html.HTMLConstants.TAG_HEAD;
+import static org.xwiki.xml.html.HTMLConstants.TAG_SCRIPT;
 
 /**
  * This is an HTML5 parser that expects valid XML as input, i.e., doesn't run HTMLCleaner.
@@ -110,6 +113,8 @@ public class XHTML5Parser extends XHTMLParser
 
         handlers.put("figure", new XWikiFigureTagHandler());
         handlers.put("figcaption", new XWikiFigcaptionTagHandler());
+        handlers.put(TAG_HEAD, new XWikiIgnoredTagHandler(TAG_HEAD));
+        handlers.put(TAG_SCRIPT, new XWikiIgnoredTagHandler(TAG_SCRIPT));
 
         XhtmlParser parser = new XhtmlParser();
         parser.setExtraHandlers(handlers);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/java/org/xwiki/rendering/internal/xhtml5/XHTML5SpecificTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/java/org/xwiki/rendering/internal/xhtml5/XHTML5SpecificTest.java
@@ -1,0 +1,34 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.xhtml5;
+
+import org.xwiki.rendering.test.integration.TestDataParser;
+import org.xwiki.rendering.test.integration.junit5.RenderingTests;
+
+/**
+ * Run all specific tests found in {@code *.test} files located in the classpath. These {@code *.test} files must follow
+ * the conventions described in {@link TestDataParser}.
+ *
+ * @version $Id$
+ */
+@RenderingTests.Scope(value = "xhtml5.specific")
+public class XHTML5SpecificTest implements RenderingTests
+{
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/resources/xhtml5/specific/head/head1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/resources/xhtml5/specific/head/head1.test
@@ -1,0 +1,22 @@
+.#-----------------------------------------------------
+.input|xhtml/5
+.#-----------------------------------------------------
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <script id="numbered-headings-config" type="application/json">
+      {
+        "isActivated": false,
+        "isActivatedOnParent": false
+      }
+    </script>
+  </head>
+  <body id="body" class="skin-flamingo viewbody main wiki-xwikispace-XWiki">
+  mybody
+  </body>
+</html>
+.#-----------------------------------------------------
+.expect|xwiki/2.1
+.#-----------------------------------------------------
+mybody

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/resources/xhtml5/specific/script/script1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml5/src/test/resources/xhtml5/specific/script/script1.test
@@ -1,0 +1,22 @@
+.#-----------------------------------------------------
+.input|xhtml/5
+.#-----------------------------------------------------
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body id="body" class="skin-flamingo viewbody main wiki-xwikispace-XWiki">
+  mybody
+    <script id="numbered-headings-config" type="application/json">
+      {
+        "isActivated": false,
+        "isActivatedOnParent": false
+      }
+    </script>
+  </body>
+</html>
+.#-----------------------------------------------------
+.expect|xwiki/2.1
+.#-----------------------------------------------------
+mybody


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XRENDERING-721

**TODO**
- [x] add for html5
- [x] also exclude `script` elements
- [x] make sure to support nested elements (not needed for the current use cases, but still safer to have it work as expected)