### PR TITLE
XRENDERING-723: Allow preparing macros

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/AbstractBlock.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/AbstractBlock.java
@@ -637,7 +637,7 @@ public abstract class AbstractBlock implements Block
     @Override
     public Optional<Syntax> getSyntaxMetadata()
     {
-        MetaDataBlock metaDataBlock = getFirstBlock(new MetadataBlockMatcher(MetaData.SYNTAX), Axes.ANCESTOR_OR_SELF);
+        MetaDataBlock metaDataBlock = getFirstBlock(MetadataBlockMatcher.SYNTAX, Axes.ANCESTOR_OR_SELF);
 
         if (metaDataBlock != null) {
             return Optional.ofNullable((Syntax) metaDataBlock.getMetaData().getMetaData(MetaData.SYNTAX));

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/AbstractBlock.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/AbstractBlock.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -33,6 +34,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.rendering.block.match.BlockMatcher;
 import org.xwiki.rendering.block.match.BlockNavigator;
 import org.xwiki.rendering.block.match.CounterBlockMatcher;
+import org.xwiki.rendering.block.match.FunctionBlockMatcher;
 import org.xwiki.rendering.block.match.MetadataBlockMatcher;
 import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.listener.MetaData;
@@ -644,5 +646,15 @@ public abstract class AbstractBlock implements Block
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> get(Function<Block, Optional<T>> searcher, Axes axes)
+    {
+        FunctionBlockMatcher<T> matcher = new FunctionBlockMatcher<>(searcher);
+
+        getFirstBlock(matcher, Axes.ANCESTOR_OR_SELF);
+
+        return matcher.getValue();
     }
 }

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/Block.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/Block.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.rendering.block.match.BlockMatcher;
@@ -359,7 +360,23 @@ public interface Block extends Cloneable
      * @return the syntax of the block or null of none could be found
      * @since 15.9RC1
      */
+    @Unstable
     default Optional<Syntax> getSyntaxMetadata()
+    {
+        return Optional.empty();
+    }
+
+    /**
+     * Get the first value extracted from the blocks in the provided {@link Axes}.
+     * 
+     * @param <T> the type of value searching in the block
+     * @param searcher the {@link Function} in charge of extracting the searched value from the block
+     * @param axes indicate the search axes
+     * @return the value found in the provided block axes
+     * @since 15.9RC1
+     */
+    @Unstable
+    default <T> Optional<T> get(Function<Block, Optional<T>> searcher, Axes axes)
     {
         return Optional.empty();
     }

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/XDOM.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/XDOM.java
@@ -53,7 +53,7 @@ public class XDOM extends MetaDataBlock
      */
     public XDOM(List<? extends Block> childBlocks)
     {
-        this(childBlocks, new IdGenerator(), MetaData.EMPTY);
+        this(childBlocks, new IdGenerator(), new MetaData());
     }
 
     /**
@@ -72,7 +72,7 @@ public class XDOM extends MetaDataBlock
      */
     public XDOM(List<? extends Block> childBlocks, IdGenerator idGenerator)
     {
-        this(childBlocks, idGenerator, MetaData.EMPTY);
+        this(childBlocks, idGenerator, new MetaData());
     }
 
     /**

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/FunctionBlockMatcher.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/FunctionBlockMatcher.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.xwiki.rendering.block.Block;
+import org.xwiki.stability.Unstable;
 
 /**
  * Search for a specific value in a {@link Block}.
@@ -31,6 +32,7 @@ import org.xwiki.rendering.block.Block;
  * @version $Id$
  * @since 15.9RC1
  */
+@Unstable
 public class FunctionBlockMatcher<T> implements BlockMatcher
 {
     private final Function<Block, Optional<T>> function;

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/FunctionBlockMatcher.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/FunctionBlockMatcher.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.block.match;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.xwiki.rendering.block.Block;
+
+/**
+ * Search for a specific value in a {@link Block}.
+ *
+ * @param <T> the type of searched value
+ * @version $Id$
+ * @since 15.9RC1
+ */
+public class FunctionBlockMatcher<T> implements BlockMatcher
+{
+    private final Function<Block, Optional<T>> function;
+
+    private Optional<T> value = Optional.empty();
+
+    /**
+     * @param function the function in charger of searching of the value in the {@link Block}
+     */
+    public FunctionBlockMatcher(Function<Block, Optional<T>> function)
+    {
+        this.function = function;
+    }
+
+    @Override
+    public boolean match(Block block)
+    {
+        Optional<T> result = this.function.apply(block);
+
+        if (result.isEmpty()) {
+            return false;
+        }
+
+        // Remember the found value
+        this.value = result;
+
+        return true;
+    }
+
+    /**
+     * @return the found value
+     */
+    public Optional<T> getValue()
+    {
+        return value;
+    }
+}

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
@@ -32,6 +32,13 @@ import org.xwiki.rendering.listener.MetaData;
 public class MetadataBlockMatcher extends ClassBlockMatcher
 {
     /**
+     * The {@link MetadataBlockMatcher} for {@link MetaData#SOURCE}.
+     * 
+     * @since 15.9RC1
+     */
+    public static final MetadataBlockMatcher SYNTAX = new MetadataBlockMatcher(MetaData.SYNTAX);
+
+    /**
      * The key of the {@link MetaData}.
      */
     private String metadataKey;

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
@@ -33,7 +33,7 @@ import org.xwiki.stability.Unstable;
 public class MetadataBlockMatcher extends ClassBlockMatcher
 {
     /**
-     * The {@link MetadataBlockMatcher} for {@link MetaData#SOURCE}.
+     * The {@link MetadataBlockMatcher} for {@link MetaData#SYNTAX}.
      * 
      * @since 15.9RC1
      */

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/block/match/MetadataBlockMatcher.java
@@ -22,6 +22,7 @@ package org.xwiki.rendering.block.match;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.listener.MetaData;
+import org.xwiki.stability.Unstable;
 
 /**
  * Implementation of {@link BlockMatcher} which matches {@link MetaData} information.
@@ -36,6 +37,7 @@ public class MetadataBlockMatcher extends ClassBlockMatcher
      * 
      * @since 15.9RC1
      */
+    @Unstable
     public static final MetadataBlockMatcher SYNTAX = new MetadataBlockMatcher(MetaData.SYNTAX);
 
     /**

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
@@ -28,8 +28,10 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.box.AbstractBoxMacro;
 import org.xwiki.rendering.macro.box.BoxMacroParameters;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
@@ -75,5 +77,11 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
         List<Block> children = getMacroContentParser().parse(content, context, false, context.isInline()).getChildren();
 
         return Collections.singletonList(new MetaDataBlock(children, this.getNonGeneratedContentMetaData()));
+    }
+
+    @Override
+    public void prepare(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        this.contentParser.prepareContentWiki(macroBlock);
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/AbstractBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/macro/box/AbstractBoxMacro.java
@@ -61,17 +61,19 @@ public abstract class AbstractBoxMacro<P extends BoxMacroParameters> extends Abs
     public static final String CONTENT_MISSING_ERROR = "The required content is missing.";
 
     /**
+     * The parser used to parse box content and box title parameter.
+     * 
+     * @since 15.9RC1
+     */
+    @Inject
+    protected MacroContentParser contentParser;
+
+    /**
      * Parses untyped image references.
      */
     @Inject
     @Named("image/untyped")
     private ResourceReferenceParser untypedImageReferenceParser;
-
-    /**
-     * The parser used to parse box content and box title parameter.
-     */
-    @Inject
-    private MacroContentParser contentParser;
 
     /**
      * Creates a new box macro.

--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacroTest.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/test/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacroTest.java
@@ -1,0 +1,57 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro.box;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.MacroContentParser;
+import org.xwiki.rendering.macro.MacroPreparationException;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Validate {@link DefaultBoxMacro}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+class DefaultBoxMacroTest
+{
+    @MockComponent
+    private MacroContentParser contentParser;
+
+    @InjectMockComponents
+    private DefaultBoxMacro macro;
+
+    @Test
+    void prepare() throws MacroPreparationException
+    {
+        MacroBlock macroBlock = new MacroBlock("content", Map.of(), false);
+
+        this.macro.prepare(macroBlock);
+
+        verify(this.contentParser).prepareContentWiki(macroBlock);
+    }
+}

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
@@ -29,13 +29,16 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.properties.converter.Converter;
 import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.AbstractMacro;
 import org.xwiki.rendering.macro.MacroContentParser;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.content.ContentMacroParameters;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.source.MacroContentWikiSource;
@@ -70,6 +73,9 @@ public class ContentMacro extends AbstractMacro<ContentMacroParameters>
 
     @Inject
     private MacroContentParser macroContentParser;
+
+    @Inject
+    private Converter<Syntax> syntaxConverter;
 
     /**
      * Used to find the Parser corresponding to the user-specified syntax for the Macro.
@@ -123,5 +129,17 @@ public class ContentMacro extends AbstractMacro<ContentMacroParameters>
 
         // Remember the metadata of the XDOM
         return List.of(new MetaDataBlock(xdom.getChildren(), xdom.getMetaData()));
+    }
+
+    @Override
+    public void prepare(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        Syntax syntax = null;
+        String syntaxString = macroBlock.getParameter("syntax");
+        if (syntaxString != null) {
+            syntax = this.syntaxConverter.convert(Syntax.class, syntaxString);
+        }
+
+        this.macroContentParser.prepareContentWiki(macroBlock, syntax);
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-footnotes/src/main/java/org/xwiki/rendering/internal/macro/footnote/FootnoteMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-footnotes/src/main/java/org/xwiki/rendering/internal/macro/footnote/FootnoteMacro.java
@@ -36,6 +36,7 @@ import org.xwiki.rendering.block.match.MacroMarkerBlockMatcher;
 import org.xwiki.rendering.macro.AbstractMacro;
 import org.xwiki.rendering.macro.MacroContentParser;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.footnote.FootnoteMacroParameters;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
@@ -126,5 +127,11 @@ public class FootnoteMacro extends AbstractMacro<FootnoteMacroParameters>
         }
 
         return this.contentParser.parse(content, context, false, true).getChildren();
+    }
+
+    @Override
+    public void prepare(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        this.contentParser.prepareContentWiki(macroBlock);
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.properties.ConverterManager;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.Block.Axes;
 import org.xwiki.rendering.block.MacroBlock;
@@ -39,11 +40,12 @@ import org.xwiki.rendering.block.MacroMarkerBlock;
 import org.xwiki.rendering.block.RawBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.block.match.ClassBlockMatcher;
-import org.xwiki.rendering.internal.transformation.macro.RawBlockFilterUtils;
 import org.xwiki.rendering.internal.transformation.MutableRenderingContext;
+import org.xwiki.rendering.internal.transformation.macro.RawBlockFilterUtils;
 import org.xwiki.rendering.macro.AbstractMacro;
 import org.xwiki.rendering.macro.MacroContentParser;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.html.HTMLMacroParameters;
 import org.xwiki.rendering.renderer.PrintRenderer;
@@ -111,6 +113,9 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
 
     @Inject
     private RawBlockFilterUtils rawBlockFilterUtils;
+
+    @Inject
+    private ConverterManager converter;
 
     /**
      * Create and initialize the descriptor of the macro.
@@ -269,5 +274,13 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
             return Syntax.HTML_5_0;
         }
         return targetSyntax;
+    }
+
+    @Override
+    public void prepare(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        if (Boolean.TRUE.equals(this.converter.convert(Boolean.class, macroBlock.getParameter("wiki")))) {
+            this.contentParser.prepareContentWiki(macroBlock);
+        }
     }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -23,8 +23,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.box.AbstractBoxMacro;
 import org.xwiki.rendering.macro.box.BoxMacroParameters;
 import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
@@ -64,5 +66,11 @@ public abstract class AbstractMessageMacro extends AbstractBoxMacro<BoxMacroPara
     protected String getClassProperty()
     {
         return super.getClassProperty() + ' ' + this.getDescriptor().getId().getId() + "message";
+    }
+
+    @Override
+    public void prepare(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        this.contentParser.prepareContentWiki(macroBlock);
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroContentParser.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/MacroContentParser.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.macro;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.syntax.Syntax;
@@ -35,6 +36,14 @@ import org.xwiki.stability.Unstable;
 @Role
 public interface MacroContentParser
 {
+    /**
+     * The name of the attribute used to store the prepared wiki content of a macro.
+     * 
+     * @since 15.9RC1
+     */
+    @Unstable
+    String ATTRIBUTE_PREPARE_CONTENT_XDOM = "prepare.content.xdom";
+
     /**
      * Parses content of a macro field (parameter, macro content) in a given syntax and optionally remove the top level
      * paragraph.
@@ -94,4 +103,33 @@ public interface MacroContentParser
      * @return the current syntax
      */
     Syntax getCurrentSyntax(MacroTransformationContext context);
+
+    /**
+     * Prepare the passed macro content as wiki content to be executed later. The prepared blocks are injected in
+     * attribute {@link #ATTRIBUTE_PREPARE_CONTENT_XDOM}.
+     * 
+     * @param macroBlock the macro to prepare
+     * @throws MacroPreparationException when failing to prepare the content
+     * @since 15.9RC1
+     */
+    @Unstable
+    default void prepareContentWiki(MacroBlock macroBlock) throws MacroPreparationException
+    {
+        prepareContentWiki(macroBlock, null);
+    }
+
+    /**
+     * Prepare the passed macro content as wiki content to be executed later. The prepared blocks are injected in
+     * attribute {@link #ATTRIBUTE_PREPARE_CONTENT_XDOM}.
+     * 
+     * @param macroBlock the macro to prepare
+     * @param syntax the syntax of the macro content, or null to use the native {@link MacroBlock} syntax
+     * @throws MacroPreparationException when failing to prepare the content
+     * @since 15.9RC1
+     */
+    @Unstable
+    default void prepareContentWiki(MacroBlock macroBlock, Syntax syntax) throws MacroPreparationException
+    {
+        
+    }
 }


### PR DESCRIPTION
The idea is to parse and prepare the content of macros for which content is parsed as wiki content:

* box
* info
* warning
* error
* success
* content
* footnote
* html

Most of the work is actually done by `MacroContentParser` which got a new API to help with the preparation of macro containing wiki content.

I also added a new generic helper in Block to simplify any code that needs to search for some special value among the tree of blocks.