### PR TITLE
Update gradle enterprise

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -52,7 +52,7 @@
       -->
       <enabled>true</enabled>
       <!-- Only CI jobs are allowed to store build outputs in the remote cache -->
-      <storeEnabled>#{env['CI'] != null}</storeEnabled>
+      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
       <server>
         <!-- Note: Remote cache authentication is handled in the Maven settings.xml file. The id below is the one
        found in settings.xml -->

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read our [Release Notes](http://www.xwiki.org/xwiki/bin/view/ReleaseNotes/).
 * [Continuous Integration](http://ci.xwiki.org/) setup launches a build for each commit
 * [Issue Tracker](http://jira.xwiki.org/browse/XRENDERING) if you want to report an issue
 * [Development Flow](http://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HGeneralDevelopmentFlow) to see the full list of tools we use to build XWiki
-* [![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.xwiki.org/scans)
+* [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.xwiki.org/scans)
 
 ## Community
 We're always looking for contributors! 


### PR DESCRIPTION
- Updated Revved up by Gradle Enterprise badge to say Revved up by Develocity (after GE -> Develocity rename)
- Updated build cache config to only push when authenticated