### PR TITLE
XRENDERING-739: Migrate to CSS3 parsing

### DIFF
--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/AbstractFormatTagHandler.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/AbstractFormatTagHandler.java
@@ -29,7 +29,7 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
 
 import com.steadystate.css.dom.CSSStyleDeclarationImpl;
 import com.steadystate.css.parser.CSSOMParser;
-import com.steadystate.css.parser.SACParserCSS21;
+import com.steadystate.css.parser.SACParserCSS3;
 
 /**
  * @version $Id$
@@ -50,7 +50,7 @@ public abstract class AbstractFormatTagHandler extends TagHandler
      * parser to use, since otherwise cssparser overrides the default parser
      * used in the JVM, breaking css4j.
      */
-    private final CSSOMParser cssParser = new CSSOMParser(new SACParserCSS21());
+    private final CSSOMParser cssParser = new CSSOMParser(new SACParserCSS3());
 
     public AbstractFormatTagHandler()
     {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-739

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Migrate to CSS3 parsing

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -pl :xwiki-rendering-wikimodel -Pquality
```

# Expected merging strategy

* Prefers squash: Yes