### PR TITLE
XRENDERING-705: Footnote macro produces inline content in standalone mode

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-footnotes/src/test/resources/macrofootnote6.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-footnotes/src/test/resources/macrofootnote6.test
@@ -2,6 +2,7 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
 .# Verify that several footnotes and putFootnotes markers work.
+.# Also verify that standalone footnote macros are converted to inline macros in a paragraph.
 .#-----------------------------------------------------
 Footnote{{footnote}}content 1{{/footnote}} {{footnote}}content 2{{/footnote}}
 
@@ -46,25 +47,30 @@ endFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_2]]
 endMacroMarkerInline [footnote] [] [content 2]
 endParagraph
 beginMacroMarkerStandalone [executedcontent] [] [{{footnote}}Inner footnote{{/footnote}}]
-beginMacroMarkerStandalone [footnote] [] [Inner footnote]
+beginParagraph
+beginMacroMarkerInline [footnote] [] [Inner footnote]
 beginFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_1]]
 beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_1]]] [false]
 onWord [3]
 endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_1]]] [false]
 endFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_1]]
-endMacroMarkerStandalone [footnote] [] [Inner footnote]
+endMacroMarkerInline [footnote] [] [Inner footnote]
+endParagraph
 endMacroMarkerStandalone [executedcontent] [] [{{footnote}}Inner footnote{{/footnote}}]
 beginMacroMarkerStandalone [executedcontent] [] [{{footnote}}Second inner footnote{{/footnote}}]
-beginMacroMarkerStandalone [footnote] [] [Second inner footnote]
+beginParagraph
+beginMacroMarkerInline [footnote] [] [Second inner footnote]
 beginFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_1-1]]
 beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_1-1]]] [false]
 onWord [4]
 endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_1-1]]] [false]
 endFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_1-1]]
-endMacroMarkerStandalone [footnote] [] [Second inner footnote]
+endMacroMarkerInline [footnote] [] [Second inner footnote]
+endParagraph
 endMacroMarkerStandalone [executedcontent] [] [{{footnote}}Second inner footnote{{/footnote}}]
 onEmptyLines [1]
-beginMacroMarkerStandalone [footnote] [] [These are the footnotes:
+beginParagraph
+beginMacroMarkerInline [footnote] [] [These are the footnotes:
 
 {{putFootnotes/}}
 ]
@@ -73,10 +79,11 @@ beginLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_5]]]
 onWord [5]
 endLink [Typed = [true] Type = [doc] Parameters = [[anchor] = [x_footnote_5]]] [false]
 endFormat [SUPERSCRIPT] [[class]=[footnoteRef][id]=[x_footnote_ref_5]]
-endMacroMarkerStandalone [footnote] [] [These are the footnotes:
+endMacroMarkerInline [footnote] [] [These are the footnotes:
 
 {{putFootnotes/}}
 ]
+endParagraph
 beginMacroMarkerStandalone [putFootnotes] []
 beginList [NUMBERED] [[class]=[footnotes]]
 beginListItem

--- a/xwiki-rendering-standalone/src/test/java/org/xwiki/rendering/example/ExampleTest.java
+++ b/xwiki-rendering-standalone/src/test/java/org/xwiki/rendering/example/ExampleTest.java
@@ -164,8 +164,8 @@ public class ExampleTest
             + "<div class=\"box warningmessage\"><p>warning</p></div>"
             + "<div class=\"box errormessage\"><p>error</p></div>"
             + "<p><strong>bold</strong></p>"
-            + "<sup><span id=\"x_footnote_ref_1\" class=\"footnoteRef\"><span class=\"wikilink\">"
-            + "<a href=\"#x_footnote_1\">1</a></span></span></sup>"
+            + "<p><sup><span id=\"x_footnote_ref_1\" class=\"footnoteRef\"><span class=\"wikilink\">"
+            + "<a href=\"#x_footnote_1\">1</a></span></span></sup></p>"
             + "<ol class=\"footnotes\"><li><span class=\"wikilink\">"
             + "<a id=\"x_footnote_1\" class=\"footnoteBackRef\" href=\"#x_footnote_ref_1\">^</a>"
             + "</span> footnote</li></ol>";


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XRENDERING-705

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* "Repair" standalone footnotes by making them inline and wrapping them in a paragraph when processing them in the putFootnotes macro.
* Adapt affected test cases.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I decided to put the repair into the putFootnotes macro as it is not possible to change the `inline` property of the macro block otherwise (it cannot be modified and replacing the whole macro block would break the macro transformation).
* I decided to put the paragraph around the macro and not inside the macro (keeping it standalone) as the user experience would be bad - users probably expect to be able to drag the standalone footnote inside some text in the WYSIWYG editor, which won't be possible with a standalone footnote.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

[Screencast_20240502_121725.webm](https://github.com/xwiki/xwiki-rendering/assets/198317/10141432-a7c7-4e5e-9298-3621335acf4f)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x