### PR TITLE
Switch order of literals to prevent NullPointerException 

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/AbstractChainingListener.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/AbstractChainingListener.java
@@ -81,7 +81,7 @@ public abstract class AbstractChainingListener implements ChainingListener
     public AbstractChainingListener()
     {
         this.listItemRetroCompatibility = needsRetroCompatibility(method -> method.getName().endsWith("ListItem"), 0);
-        this.imageRetroCompatibility = needsRetroCompatibility(method -> method.getName().equals("onImage"), 3);
+        this.imageRetroCompatibility = needsRetroCompatibility(method -> "onImage".equals(method.getName()), 3);
     }
 
     /**

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiMacroHandler.java
@@ -72,7 +72,7 @@ public class XWikiMacroHandler implements XWikiWikiModelHandler
     private String getSyntax(TagContext previousNodes, String macroType)
     {
         // if the type is not wiki content type, then we should parse the content as plain text.
-        if (!macroType.equals(WIKI_CONTENT_TYPE)) {
+        if (!WIKI_CONTENT_TYPE.equals(macroType)) {
             return Syntax.PLAIN_1_0.toIdString();
         } else if (previousNodes.getTagStack().getStackParameter(CURRENT_SYNTAX) != null) {
             return (String) previousNodes.getTagStack().popStackParameter(CURRENT_SYNTAX);


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fxwiki-rendering%7Cee2e64ab1658b36aaf4e8cc707985f5a20f74f00)


<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->