### PR TITLE
XRENDERING-744: Nested lists with paragraphs are incorrectly rendered and cause NPEs

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/list/list.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/list/list.test
@@ -1,0 +1,57 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<ol>
+  <li><p>Hello</p></li>
+  <li><p>world</p>
+    <ol>
+      <li><p>Hello nested</p></li>
+      <li><p>world nested</p></li>
+    </ol>
+  </li>
+</ol>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginList [NUMBERED]
+beginListItem
+beginGroup
+beginParagraph
+onWord [Hello]
+endParagraph
+endGroup
+endListItem
+beginListItem
+beginGroup
+beginParagraph
+onWord [world]
+endParagraph
+beginList [NUMBERED]
+beginListItem
+beginGroup
+beginParagraph
+onWord [Hello]
+onSpace
+onWord [nested]
+endParagraph
+endGroup
+endListItem
+beginListItem
+beginGroup
+beginParagraph
+onWord [world]
+onSpace
+onWord [nested]
+endParagraph
+endGroup
+endListItem
+endList [NUMBERED]
+endGroup
+endListItem
+endList [NUMBERED]
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<ol><li><div><p>Hello</p></div></li><li><div><p>world</p><ol><li><div><p>Hello nested</p></div></li><li><div><p>world nested</p></div></li></ol></div></li></ol>

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/ListTagHandler.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/ListTagHandler.java
@@ -38,8 +38,9 @@ public class ListTagHandler extends TagHandler
         TagContext parent = context.getParent();
         // A new list is considered a block element only if the parent is not a
         // list item since nested lists
-        // are not new block elements
-        return !(parent.isTag("li") || parent.isTag("dd") || parent.isTag("dt"));
+        // are not new block elements - unless the parent got a nested document.
+        boolean isInListItem = parent.isTag("li") || parent.isTag("dd") || parent.isTag("dt");
+        return !isInListItem || parent == parent.getTagStack().getDocumentParent();
     }
 
     @Override

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagContext.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagContext.java
@@ -108,7 +108,7 @@ public class TagContext
     {
         // If my parent is not handled, I want it to be fully ignored, so I will go up the tree until I found
         // a handled parent, however I should not reach the root.
-        if (fParent.fHandler == null && fParent.fParent.fName != null) {
+        if (fParent.fHandler == null && fParent.fParent != null && fParent.fParent.fName != null) {
             return fParent.getParent();
         } else {
             return fParent;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-744

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Treat lists that are in a list item but where the list item has a nested document as block handlers.
* Bulletproof TagContext.getParent against being called on the root tag context.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

Lists that are wrapped in other list items [are not "block handlers"](https://github.com/xwiki/xwiki-rendering/blob/a610c0ce518745875746fc5ab90b706e2649f3c4/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/handler/ListTagHandler.java#L39-L42) as they don't require, e.g., a nested document tag. However, as, when the inner list starts, we are directly inside the created group syntax, we are not in a block context when the paragraph is opened. Therefore, the paragraph tag handler doesn't trigger the opening of a nested document. In the `InternalWikiScannerContext` the opening of the paragraph then closes the list before opening the paragraph.

I think the correct thing to do is to consider lists as block handlers if a nested document tag was opened. This fixes this example for me (see the test added in this pull request).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality
```
in `xwiki-rendering`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x