### PR TITLE
XRENDERING-619: Lists with nested paragraphs are incorrectly converted to XWiki syntax

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/list/list15.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/list/list15.test
@@ -1,0 +1,106 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Test plain text content before a nested list starts.
+.#-----------------------------------------------------
+ <ol>
+   <li>
+     Paragraph 5
+     <ol>
+       <li>Paragraph 5.1
+         <ol>
+           <li>Paragraph 5.1.1
+           <p>Some text.</p>
+           </li>
+         </ol>
+       </li>
+       <li>Paragraph 5.2
+         <ol>
+           <li>Paragraph 5.2.1
+             <p>Example notes:</p>
+           </li>
+         </ol>
+       </li>
+     </ol>
+   </li>
+ </ol>
+.#-----------------------------------------------------
+.expect|xwiki/2.1
+.#-----------------------------------------------------
+1. (((
+Paragraph 5
+
+1. Paragraph 5.1
+11. Paragraph 5.1.1(((
+Some text.
+)))
+1. Paragraph 5.2
+11. Paragraph 5.2.1(((
+Example notes:
+)))
+)))
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginList [NUMBERED]
+beginListItem
+onWord [Paragraph]
+onSpace
+onWord [5]
+beginList [NUMBERED]
+beginListItem
+onWord [Paragraph]
+onSpace
+onWord [5]
+onSpecialSymbol [.]
+onWord [1]
+beginList [NUMBERED]
+beginListItem
+onWord [Paragraph]
+onSpace
+onWord [5]
+onSpecialSymbol [.]
+onWord [1]
+onSpecialSymbol [.]
+onWord [1]
+beginGroup
+beginParagraph
+onWord [Some]
+onSpace
+onWord [text]
+onSpecialSymbol [.]
+endParagraph
+endGroup
+endListItem
+endList [NUMBERED]
+endListItem
+beginListItem
+onWord [Paragraph]
+onSpace
+onWord [5]
+onSpecialSymbol [.]
+onWord [2]
+beginList [NUMBERED]
+beginListItem
+onWord [Paragraph]
+onSpace
+onWord [5]
+onSpecialSymbol [.]
+onWord [2]
+onSpecialSymbol [.]
+onWord [1]
+beginGroup
+beginParagraph
+onWord [Example]
+onSpace
+onWord [notes]
+onSpecialSymbol [:]
+endParagraph
+endGroup
+endListItem
+endList [NUMBERED]
+endListItem
+endList [NUMBERED]
+endListItem
+endList [NUMBERED]
+endDocument

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -907,6 +907,17 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
 
     private void print(String text, boolean isDelayed)
     {
+        // In principle, anything that's printed means that the first element has been rendered, e.g., at the start
+        // of a group syntax.
+        // However, newline handling is not consistent between rendering and parsing.
+        // At the start of a group syntax, the parser detects more empty lines than what the renderer produces if it
+        // prints both the empty lines and the line breaks produced by printEmptyLine() when isFirstElementRendered
+        // is true.
+        // To avoid that, don't set isFirstElementRendered to true when just line breaks are printed.
+        if (!StringUtils.containsOnly(text, '\n')) {
+            this.isFirstElementRendered = true;
+        }
+
         // Handle empty formatting parameters.
         handleEmptyParameters();
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XRENDERING-619

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add an integration test to test the behavior
* Make the detection of first element rendered more robust.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I decided not to address the problem of empty lines at the beginning of groups and documents being lost, while removing the condition that is added here leads to more newlines being printed, these seem to be too many newlines/more than the parser expects. I didn't dig deeper what causes this mismatch.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality
```
in `xwiki-rendering`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-15.10.x