### PR TITLE
XRENDERING-749: Deprecated MacroDescriptor's getDefaultCategory() is ignored

### DIFF
--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/main/aspect/org/xwiki/rendering/macro/descriptor/AbstractMacroDescriptorAspect.aj
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/main/aspect/org/xwiki/rendering/macro/descriptor/AbstractMacroDescriptorAspect.aj
@@ -46,10 +46,7 @@ public privileged aspect AbstractMacroDescriptorAspect
     public AbstractMacroDescriptor.new(String name, String description, ContentDescriptor contentDescriptor,
         BeanDescriptor parametersBeanDescriptor)
         {
-            this.name = name;
-            this.description = description;
-            this.contentDescriptor = contentDescriptor;
-            this.parametersBeanDescriptor = parametersBeanDescriptor;
+            this(null, name, description, contentDescriptor, parametersBeanDescriptor);
         }
     
     /**

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/main/aspect/org/xwiki/rendering/macro/descriptor/MacroDescriptorAspect.java
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/main/aspect/org/xwiki/rendering/macro/descriptor/MacroDescriptorAspect.java
@@ -19,13 +19,40 @@
  */
 package org.xwiki.rendering.macro.descriptor;
 
+import java.util.Set;
+
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.DeclareParents;
+
 /**
  * Add a backward compatibility layer to {@link MacroDescriptor}.
  *
  * @version $Id$
  * @since 14.8RC1
  */
-public privileged aspect MacroDescriptorAspect
+@Aspect
+public class MacroDescriptorAspect
 {
-    declare parents : MacroDescriptor implements CompatibilityMacroDescriptor;
+    /**
+     * Add legacy APIs to {@link MacroDescriptor}.
+     */
+    @DeclareParents("MacroDescriptor")
+    public static CompatibilityMacroDescriptor compatibility;
+
+    /**
+     * Overwrite the default implementation of #getDefaultCategories based on the legacy #getDefaultCategory.
+     *
+     * @param descriptor the legacy descriptor API
+     * @return a set containing the default category
+     * @since 14.10.22
+     * @since 15.10.11
+     * @since 16.4.1
+     * @since 16.5.0
+     */
+    @Around("execution(Set<String> MacroDescriptor.getDefaultCategories()) && target(descriptor)")
+    public Set<String> aroundGetDefaultCategories(CompatibilityMacroDescriptor descriptor)
+    {
+        return Set.of(descriptor.getDefaultCategory());
+    }
 }

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/DeprecatedMacroDescriptorTest.java
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/src/test/java/org/xwiki/rendering/macro/descriptor/DeprecatedMacroDescriptorTest.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.macro.descriptor;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.macro.MacroId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Validate the retro compatibility of interface {@link MacroDescriptor}.
+ * 
+ * @version $Id$
+ */
+class DeprecatedMacroDescriptorTest
+{
+    private static class TestMacroDescriptor implements MacroDescriptor
+    {
+        @Override
+        public MacroId getId()
+        {
+            return null;
+        }
+
+        @Override
+        public String getName()
+        {
+            return null;
+        }
+
+        @Override
+        public String getDescription()
+        {
+            return null;
+        }
+
+        @Override
+        public Class<?> getParametersBeanClass()
+        {
+            return null;
+        }
+
+        @Override
+        public ContentDescriptor getContentDescriptor()
+        {
+            return null;
+        }
+
+        @Override
+        public Map<String, ParameterDescriptor> getParameterDescriptorMap()
+        {
+            return null;
+        }
+
+        @Override
+        public String getDefaultCategory()
+        {
+            return "deprecatedcategory";
+        }
+    }
+
+    @Test
+    void getDefaultCategory()
+    {
+        TestMacroDescriptor descriptor = new TestMacroDescriptor();
+
+        assertEquals(Set.of("deprecatedcategory"), descriptor.getDefaultCategories());
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XRENDERING-749

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Fix a retro compatibility breakage introduced by XRENDERING-664.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Unit test added in DeprecatedMacroDescriptorTest.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: all supported branches