### PR TITLE
XRENDERING-768: Multiple paragraphs in the info macro do not result in multiple lines

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -124,8 +124,8 @@ public abstract class AbstractMessageMacro extends AbstractBoxMacro<BoxMacroPara
         List<Block> boxFoundation = super.execute(parameters, content, context);
         if (!boxFoundation.isEmpty() && getIconName() != null) {
             Block defaultBox = boxFoundation.get(0);
-            // For an easier styling, we wrap the content and title together if they are non-empty and visible
-            if (defaultBox.getChildren().size() > 1) {
+            if (!context.isInline()) {
+                // For an easier styling, we always wrap the content of standalone blocks in a div.
                 Block boxTextContent = new GroupBlock(defaultBox.getChildren());
                 defaultBox.setChildren(List.of(boxTextContent));
             }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -125,7 +125,7 @@ public abstract class AbstractMessageMacro extends AbstractBoxMacro<BoxMacroPara
         if (!boxFoundation.isEmpty() && getIconName() != null) {
             Block defaultBox = boxFoundation.get(0);
             if (!context.isInline()) {
-                // For an easier styling, we always wrap the content of standalone blocks in a div.
+                // For an easier styling, we always wrap the content of standalone blocks in a group.
                 Block boxTextContent = new GroupBlock(defaultBox.getChildren());
                 defaultBox.setChildren(List.of(boxTextContent));
             }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/java/org/xwiki/rendering/macro/message/MessageMacroTest.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/java/org/xwiki/rendering/macro/message/MessageMacroTest.java
@@ -100,7 +100,9 @@ class MessageMacroTest
         assertEquals("(% class=\"box infomessage\" %)\n"
             + "(((\n"
             + "(% class=\"sr-only\" %)Info(%%)\n\n"
+            + "(((\n"
             + "content\n"
+            + ")))\n"
             + ")))", printer.toString());
     }
 

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage1.test
@@ -22,6 +22,7 @@ beginMacroMarkerStandalone [info] [] [Failed to do this action. The correct poss
 * another possibility]
 beginGroup [[class]=[box infomessage]]
 onImage [Typed = [true] Type = [icon] Reference = [information]] [true]
+beginGroup
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
 onWord [Failed]
@@ -70,6 +71,7 @@ onWord [possibility]
 endListItem
 endList [BULLETED]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endGroup
 endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage2.test
@@ -18,6 +18,7 @@ beginMacroMarkerStandalone [warning] [] [Failed to do this action. The correct p
 * another possibility]
 beginGroup [[class]=[box warningmessage]]
 onImage [Typed = [true] Type = [icon] Reference = [error]] [true]
+beginGroup
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
 onWord [Failed]
@@ -66,6 +67,7 @@ onWord [possibility]
 endListItem
 endList [BULLETED]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endGroup
 endGroup [[class]=[box warningmessage]]
 endMacroMarkerStandalone [warning] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage3.test
@@ -18,6 +18,7 @@ beginMacroMarkerStandalone [error] [] [Failed to do this action. The correct pos
 * another possibility]
 beginGroup [[class]=[box errormessage]]
 onImage [Typed = [true] Type = [icon] Reference = [exclamation]] [true]
+beginGroup
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
 onWord [Failed]
@@ -66,6 +67,7 @@ onWord [possibility]
 endListItem
 endList [BULLETED]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endGroup
 endGroup [[class]=[box errormessage]]
 endMacroMarkerStandalone [error] [] [Failed to do this action. The correct possibilities are:
 * use another value

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/test/resources/macromessage4.test
@@ -15,6 +15,7 @@ beginMacroMarkerStandalone [info] [] [* item1
 * item2]
 beginGroup [[class]=[box infomessage]]
 onImage [Typed = [true] Type = [icon] Reference = [information]] [true]
+beginGroup
 beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginList [BULLETED]
 beginListItem
@@ -25,6 +26,7 @@ onWord [item2]
 endListItem
 endList [BULLETED]
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endGroup
 endGroup [[class]=[box infomessage]]
 endMacroMarkerStandalone [info] [] [* item1
 * item2]


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22761

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the returned DOM of the generic message so that the content is always wrapped appart from the icon. It allows for styles used on this macro to be more reliable.
* Updated tests

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* the DOM was quite inconsistent because we had the content at the same level as other elements of the message box. Now we made sure the content is always wrapped in a group (when the macro standalone). This way it makes styling the box easier with CSS because you don't have to account for content style interfering with the box style and the box style interfering with content style (at least not more than by CSS inheritance).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
![Screenshot from 2025-01-08 10-22-08](https://github.com/user-attachments/assets/123a39c5-65c9-472c-be0a-b116e9db1176)
After the PR:
![image](https://github.com/user-attachments/assets/66faa354-91df-4adc-bba2-8f29c947d7d2)
Note that at the end of the screenshot, there's a weird display when we try to use multiline content in an inline macro. This is not a regression and already happened before thge changes brought in XWIKI-21452.

For reference, the source of this page is:

<details> <summary>Source</summary>

```
{{info}}
There should be
  
two lines.
{{/info}}
{{info}}
There should be
two lines.
{{/info}}
___
{{info title="title"}}
There should be
  
two lines.
{{/info}}
{{info title="title"}}
There should be
two lines.
{{/info}}
___
{{info image="folder_wrench.png"}}
There should be
  
two lines.
{{/info}}
{{info image="folder_wrench.png"}}
There should be
two lines.
{{/info}}
___
{{info title="title" image="folder_wrench.png"}}
There should be
  
two lines.
{{/info}}
{{info title="title" image="folder_wrench.png"}}
There should be
two lines.
{{/info}}
____
____
inline:{{info}}
There should be
  
two lines.
{{/info}}
inline:{{info}}
There should be
two lines.
{{/info}}
_____
inline:{{box}}
There should be
  
two lines.
{{/box}}
inline:{{box}}
There should be
two lines.
{{/box}}
```

</details>

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I tested `mvn clean install -f xwiki-rendering-macros/xwiki-rendering-macro-message -Pquality,integration-tests,docker` and after updating the tests, it passed successfully. I used this build of the xwiki-rendering-macro-message JAR on a local instance and tested it manually to make sure it didn't break anything (see screenshot above).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (same as XRENDERING-736)