### PR TITLE
XRENDERING-684: Empty lines get removed below tables and lists after saving in wysiwyg editor

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/ListenerChain.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/ListenerChain.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Stores information about the listeners in the chain and the order in which they need to be called. Also sports a
  * feature that allows pushing and popping listeners that are stackable. This feature is useful since listeners can hold
@@ -49,6 +51,8 @@ public class ListenerChain
      * class object and then the instance can be found in {@link #listeners}.
      */
     private List<Class<? extends ChainingListener>> nextListeners = new ArrayList<>();
+
+    private int stackingDepth;
 
     /**
      * @param listener the chaining listener to add to the chain. If an instance of that listener is already present
@@ -168,6 +172,8 @@ public class ListenerChain
         for (Class<? extends ChainingListener> listenerClass : this.listeners.keySet()) {
             pushListener(listenerClass);
         }
+
+        ++this.stackingDepth;
     }
 
     /**
@@ -178,6 +184,22 @@ public class ListenerChain
         for (Class<? extends ChainingListener> listenerClass : this.listeners.keySet()) {
             popListener(listenerClass);
         }
+
+        --this.stackingDepth;
+    }
+
+    /**
+     * @return the depth of the listener stack. The depth is the number of times
+     * {@link ListenerChain#pushAllStackableListeners()} has been called minus the number of times
+     * {@link ListenerChain#popAllStackableListeners()} has been called.
+     * @since 16.4.7
+     * @since 16.10.3
+     * @since 17.0.0RC1
+     */
+    @Unstable
+    public int getStackingDepth()
+    {
+        return this.stackingDepth;
     }
 
     /**

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -547,7 +547,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
             int newLinesToPrint = count;
             // After tables and lists, we need an extra newline for newlines to be recognized.
             BlockStateChainingListener.Event previousEvent = this.getBlockState().getPreviousEvent();
-            if ((previousEvent != null && NEWLINE_HIDING_ELEMENTS.contains(previousEvent))) {
+            if (previousEvent != null && NEWLINE_HIDING_ELEMENTS.contains(previousEvent)) {
                 newLinesToPrint += 1;
             }
 

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/emptylines/emptylines1.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/emptylines/emptylines1.test
@@ -1,0 +1,54 @@
+.#-------------------------------------------------------------------------------------------------------
+.inputexpect|xwiki/2.0
+.#-------------------------------------------------------------------------------------------------------
+|=heading 1|=heading 2
+|value 1|value 2
+
+Some text
+
+|=heading 1|=heading 2
+|value 1|value 2
+
+
+
+= Header =
+
+
+* List item
+** Nested List
+
+
+
+; Term
+: Definition
+
+
+
+|=heading 1|=heading 2
+|value 1|value 2
+
+
+
+{{macro/}}
+
+
+Some text
+
+
+|=heading 1|=heading 2
+|value 1|value 2
+
+
+
+some text
+
+paragraph1
+
+paragraph2
+
+
+paragraph3
+
+
+
+paragraph4

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/emptylines/emptylines2.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/emptylines/emptylines2.test
@@ -1,0 +1,167 @@
+.#-------------------------------------------------------------------------------------------------------
+.input|xwiki/2.0
+.# Test limitations regarding empty line handling in group syntax. It is impossible to have a single empty line at the
+.# end of a group (or as only content).
+.#-------------------------------------------------------------------------------------------------------
+
+
+
+(((
+)))
+
+(((
+
+)))
+
+(((
+
+
+)))
+
+(((
+
+
+
+)))
+
+(((
+Content
+)))
+
+(((
+
+Content
+
+)))
+
+* List
+
+(((
+
+
+Content
+
+
+* List
+
+
+
+)))
+
+(((
+
+
+= heading =
+
+
+)))
+.#-------------------------------------------------------------------------------------------------------
+.inputexpect|xwiki/2.0
+.# Changes compared to input:
+.# * Inside a group there is always at least an empty line (which is the same as no empty line)
+.# * A single empty line at the start and end of the group is the same as no empty line
+.#-------------------------------------------------------------------------------------------------------
+
+
+
+(((
+
+)))
+
+(((
+
+)))
+
+(((
+
+
+)))
+
+(((
+
+
+
+)))
+
+(((
+Content
+)))
+
+(((
+Content
+)))
+
+* List
+
+(((
+
+
+Content
+
+
+* List
+
+
+
+)))
+
+(((
+
+
+= heading =
+
+
+)))
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onEmptyLines [1]
+beginGroup
+endGroup
+beginGroup
+endGroup
+beginGroup
+onEmptyLines [2]
+endGroup
+beginGroup
+onEmptyLines [3]
+endGroup
+beginGroup
+beginParagraph
+onWord [Content]
+endParagraph
+endGroup
+beginGroup
+beginParagraph
+onWord [Content]
+endParagraph
+endGroup
+beginList [BULLETED]
+beginListItem
+onWord [List]
+endListItem
+endList [BULLETED]
+beginGroup
+onEmptyLines [1]
+beginParagraph
+onWord [Content]
+endParagraph
+onEmptyLines [1]
+beginList [BULLETED]
+beginListItem
+onWord [List]
+endListItem
+endList [BULLETED]
+onEmptyLines [2]
+endGroup
+beginGroup
+onEmptyLines [1]
+beginSection
+beginHeader [1, Hheading]
+onWord [heading]
+endHeader [1, Hheading]
+onEmptyLines [2]
+endSection
+endGroup
+endDocument


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

* https://jira.xwiki.org/browse/XRENDERING-684
* https://jira.xwiki.org/browse/XRENDERING-667
* https://jira.xwiki.org/browse/XRENDERING-98

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Align the renderer with the parser regarding empty line handling:

* At the start of the document, we need two extra newlines.
* At the start of a group, we need one extra newline, unless the group is otherwise empty, then one newline less should be printed.
* After tables, lists and definition lists, we need one extra newline.

This also fixes XRENDERING-667: New lines added when parsing and re-rendering groups in xwiki/2.1
Further, it partially implements XRENDERING-98 for the beginning of the content: Make empty lines at beginning and end of content significant for XWiki Syntax 2.2.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This doesn't touch the parser as this would break backwards-compatibility.
* From what I can see, the changes are quite limited to those cases that need fixing and shouldn't cause any regressions, but there is always a risk.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests,standalone
```
in `xwiki-rendering`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x