### PR TITLE
XRENDERING-771: Null pointer exception when list items occur without lists

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/listener/chaining/BlockStateChainingListener.java
@@ -278,6 +278,10 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     public void beginDefinitionDescription()
     {
         ++this.inlineDepth;
+        if (this.definitionListDepth.isEmpty()) {
+            // Avoid a null pointer exception. The result might be wrong but at least it won't break.
+            this.definitionListDepth.push(new DefinitionListState());
+        }
         ++this.definitionListDepth.peek().definitionListItemIndex;
 
         super.beginDefinitionDescription();
@@ -304,6 +308,10 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     public void beginDefinitionTerm()
     {
         ++this.inlineDepth;
+        if (this.definitionListDepth.isEmpty()) {
+            // Avoid a null pointer exception. The result might be wrong but at least it won't break.
+            this.definitionListDepth.push(new DefinitionListState());
+        }
         ++this.definitionListDepth.peek().definitionListItemIndex;
 
         super.beginDefinitionTerm();
@@ -340,6 +348,10 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     public void beginListItem()
     {
         ++this.inlineDepth;
+        if (this.listDepth.isEmpty()) {
+            // Avoid a null pointer exception. The result might be wrong but at least it won't break.
+            this.listDepth.push(new ListState());
+        }
         ++this.listDepth.peek().listItemIndex;
 
         super.beginListItem();
@@ -351,6 +363,10 @@ public class BlockStateChainingListener extends AbstractChainingListener impleme
     public void beginListItem(Map<String, String> parameters)
     {
         ++this.inlineDepth;
+        if (this.listDepth.isEmpty()) {
+            // Avoid a null pointer exception. The result might be wrong but at least it won't break.
+            this.listDepth.push(new ListState());
+        }
         ++this.listDepth.peek().listItemIndex;
 
         super.beginListItem(parameters);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-771

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Protect against list items without wrapping list.
* Add tests.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This will most likely result in incorrect outputs as the rest of the events will believe they are inside a list. I'm not sure though it makes sense to fix this.
* I'm wondering if the renderer should log a warning to notify the admin that something wrong happened. The problem with this is that I don't know what context the log could provide to let the admin understand where the problem happened. However, maybe the log message itself could have enough context (URL?)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests,standalone
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x