### PR TITLE
XRENDERING-778: Rendering a page with thousands of macros is slow

### DIFF
--- a/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-box/src/main/java/org/xwiki/rendering/internal/macro/box/DefaultBoxMacro.java
@@ -84,4 +84,10 @@ public class DefaultBoxMacro<P extends BoxMacroParameters> extends AbstractBoxMa
     {
         this.contentParser.prepareContentWiki(macroBlock);
     }
+
+    @Override
+    public boolean isExecutionIsolated(P parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-comment/src/main/java/org/xwiki/rendering/internal/macro/comment/CommentMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-comment/src/main/java/org/xwiki/rendering/internal/macro/comment/CommentMacro.java
@@ -76,4 +76,10 @@ public class CommentMacro extends AbstractNoParameterMacro
     {
         return Collections.emptyList();
     }
+
+    @Override
+    public boolean isExecutionIsolated(Object parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-content/src/main/java/org/xwiki/rendering/internal/macro/content/ContentMacro.java
@@ -142,4 +142,10 @@ public class ContentMacro extends AbstractMacro<ContentMacroParameters>
 
         this.macroContentParser.prepareContentWiki(macroBlock, syntax);
     }
+
+    @Override
+    public boolean isExecutionIsolated(ContentMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-html/src/main/java/org/xwiki/rendering/internal/macro/html/HTMLMacro.java
@@ -283,4 +283,10 @@ public class HTMLMacro extends AbstractMacro<HTMLMacroParameters>
             this.contentParser.prepareContentWiki(macroBlock);
         }
     }
+
+    @Override
+    public boolean isExecutionIsolated(HTMLMacroParameters parameters, String content)
+    {
+        return !parameters.getWiki();
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-id/src/main/java/org/xwiki/rendering/internal/macro/id/IdMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-id/src/main/java/org/xwiki/rendering/internal/macro/id/IdMacro.java
@@ -79,4 +79,10 @@ public class IdMacro extends AbstractMacro<IdMacroParameters>
 
         return Collections.singletonList((Block) idBlock);
     }
+
+    @Override
+    public boolean isExecutionIsolated(IdMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-message/src/main/java/org/xwiki/rendering/internal/macro/message/AbstractMessageMacro.java
@@ -164,4 +164,10 @@ public abstract class AbstractMessageMacro extends AbstractBoxMacro<MessageMacro
         }
         return iconBlock;
     }
+
+    @Override
+    public boolean isExecutionIsolated(MessageMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-raw/src/main/java/org/xwiki/rendering/internal/macro/raw/RawMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-raw/src/main/java/org/xwiki/rendering/internal/macro/raw/RawMacro.java
@@ -99,4 +99,10 @@ public class RawMacro extends AbstractMacro<RawMacroParameters>
 
         return Collections.singletonList(rawBlock);
     }
+
+    @Override
+    public boolean isExecutionIsolated(RawMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/AbstractTocMacro.java
+++ b/xwiki-rendering-macros/xwiki-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/AbstractTocMacro.java
@@ -124,4 +124,11 @@ public abstract class AbstractTocMacro<T extends TocMacroParameters> extends Abs
             throw new MacroExecutionException(String.format("Failed to get XDOM for [%s]", reference), e);
         }
     }
+
+    @Override
+    public boolean isExecutionIsolated(T parameters, String content)
+    {
+        // While the TOC macro accesses the XDOM, it doesn't modify it.
+        return true;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/pom.xml
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/pom.xml
@@ -79,6 +79,7 @@
               <includes>
                 <!-- Required since we're using test components in the integration test module  -->
                 <include>**/Test*Macro.class</include>
+                <include>**/Test*Macros.class</include>
                 <include>**/Test*Macro$*.class</include>
                 <include>**/TestMacroParameter.class</include>
                 <include>**/components.txt</include>

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfiguration.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfiguration.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.transformation.macro;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
@@ -44,17 +45,21 @@ public class IsolatedExecutionConfiguration
     @Named("restricted")
     private Provider<ConfigurationSource> configurationSourceProvider;
 
-    private final Map<String, Boolean> cache = new ConcurrentHashMap<>();
+    // Cache configuration values as converting the configuration value to Boolean is kind of slow because it uses a
+    // context component manager.
+    private final Map<String, Optional<Boolean>> cache = new ConcurrentHashMap<>();
 
     /**
      * @param macroId the ID of the macro
+     * @param defaultValue the default value to return if the configuration is not set
      * @return if the execution of the macro is isolated according to the configuration
      */
-    public boolean isExecutionIsolated(String macroId)
+    public boolean isExecutionIsolated(String macroId, boolean defaultValue)
     {
-        return this.cache.computeIfAbsent(macroId, k -> {
-            ConfigurationSource configuration = this.configurationSourceProvider.get();
-            return configuration.getProperty("rendering.macro.%s.executionIsolated".formatted(macroId), Boolean.FALSE);
-        });
+        return this.cache.computeIfAbsent(macroId,
+                k -> Optional.ofNullable(
+                    this.configurationSourceProvider.get()
+                        .getProperty("rendering.macro." + k + ".executionIsolated", Boolean.class, null)))
+            .orElse(defaultValue);
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfiguration.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.transformation.macro;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * A caching wrapper around the isolated execution configuration.
+ *
+ * @version $Id$
+ * @since 17.3.0RC1
+ */
+@Component(roles = IsolatedExecutionConfiguration.class)
+@Singleton
+public class IsolatedExecutionConfiguration
+{
+    @Inject
+    @Named("restricted")
+    private Provider<ConfigurationSource> configurationSourceProvider;
+
+    private final Map<String, Boolean> cache = new ConcurrentHashMap<>();
+
+    /**
+     * @param macroId the ID of the macro
+     * @return if the execution of the macro is isolated according to the configuration
+     */
+    public boolean isExecutionIsolated(String macroId)
+    {
+        return this.cache.computeIfAbsent(macroId, k -> {
+            ConfigurationSource configuration = this.configurationSourceProvider.get();
+            return configuration.getProperty("rendering.macro.%s.executionIsolated".formatted(macroId), Boolean.FALSE);
+        });
+    }
+}

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
@@ -295,6 +295,9 @@ public class MacroTransformation extends AbstractTransformation implements Initi
     @Inject
     private ErrorBlockGenerator errorBlockGenerator;
 
+    @Inject
+    private IsolatedExecutionConfiguration isolatedExecutionConfiguration;
+
     /**
      * Used to generate Macro error blocks when a Macro fails to execute.
      */
@@ -388,7 +391,9 @@ public class MacroTransformation extends AbstractTransformation implements Initi
                     continue;
                 }
 
-                if (!((Macro<Object>) macro).isExecutionIsolated(macroParameters, macroBlock.getContent())) {
+                if (!((Macro<Object>) macro).isExecutionIsolated(macroParameters, macroBlock.getContent())
+                    && !this.isolatedExecutionConfiguration.isExecutionIsolated(macroBlock.getId()))
+                {
                     priorityMacroBlockMatcher.reset();
                 }
                 newBlocks = ((Macro) macro).execute(macroParameters, macroBlock.getContent(), macroContext);

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
@@ -391,8 +391,8 @@ public class MacroTransformation extends AbstractTransformation implements Initi
                     continue;
                 }
 
-                if (!((Macro<Object>) macro).isExecutionIsolated(macroParameters, macroBlock.getContent())
-                    && !this.isolatedExecutionConfiguration.isExecutionIsolated(macroBlock.getId()))
+                if (!this.isolatedExecutionConfiguration.isExecutionIsolated(macroBlock.getId(),
+                    ((Macro<Object>) macro).isExecutionIsolated(macroParameters, macroBlock.getContent())))
                 {
                     priorityMacroBlockMatcher.reset();
                 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
@@ -432,7 +432,7 @@ public class MacroTransformation extends AbstractTransformation implements Initi
                 Block resultBlock = wrapInMacroMarker(macroBlock, newBlocks);
 
                 if (!priorityMacroBlockMatcher.isFullScanNeeded()) {
-                    // Find descendant blocks if no full scann is needed. Those descendant blocks will be inserted
+                    // Find descendant blocks if no full scan is needed. Those descendant blocks will be inserted
                     // into the existing priority queue with indexes that are in the same position as the current macro.
                     BlockMatcher childrenMatcher = priorityMacroBlockMatcher.getChildrenMatcher(macroItem);
                     resultBlock.getFirstBlock(childrenMatcher, Block.Axes.DESCENDANT);

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/Macro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/Macro.java
@@ -26,6 +26,7 @@ import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.stability.Unstable;
 
 /**
  * Represents a Macro, ie a mechanism to generate Rendering {@link Block}s, that we use as a way to either generate
@@ -85,5 +86,20 @@ public interface Macro<P> extends Comparable<Macro<?>>
     default void prepare(MacroBlock macroBlock) throws MacroPreparationException
     {
         // Do nothing by default
+    }
+
+    /**
+     * @param parameters the parameters with which the macro would be executed
+     * @param content the content with which the macro would be executed
+     * @return {@code true}, if executing the macro with the parameters definitely won't modify the XDOM,
+     * {@code false}, otherwise.
+     * A macro needs to return {@code false} if it executes macro transformations with macros it doesn't know
+     * (e.g., parsed from its content or another page) with the XDOM or the macro block accessible for these macros.
+     * @since 17.3.0RC1
+     */
+    @Unstable
+    default boolean isExecutionIsolated(P parameters, String content)
+    {
+        return false;
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/resources/META-INF/components.txt
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/resources/META-INF/components.txt
@@ -8,4 +8,5 @@ org.xwiki.rendering.internal.macro.source.StringMacroWikiContentSourceFactory
 org.xwiki.rendering.internal.transformation.macro.MacroTransformation
 org.xwiki.rendering.internal.transformation.macro.DefaultMacroTransformationConfiguration
 org.xwiki.rendering.internal.transformation.macro.HTMLRawBlockFilter
+org.xwiki.rendering.internal.transformation.macro.IsolatedExecutionConfiguration
 org.xwiki.rendering.internal.transformation.macro.RawBlockFilterUtils

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
@@ -226,7 +226,8 @@ class DefaultMacroManagerTest
             new MacroId("testsimpleinlinemacro"),
             new MacroId("testfailingmacro"),
             new MacroId("testReplaceMe"),
-            new MacroId("testReplacement")
+            new MacroId("testReplacement"),
+            new MacroId("testtwonestedmacros")
         ), this.macroManager.getMacroIds());
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfigurationTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfigurationTest.java
@@ -36,6 +36,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link IsolatedExecutionConfiguration}.
+ *
+ * @version $Id$
+ */
 @ComponentTest
 class IsolatedExecutionConfigurationTest
 {

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfigurationTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/IsolatedExecutionConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.transformation.macro;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ComponentTest
+class IsolatedExecutionConfigurationTest
+{
+    @MockComponent
+    @Named("restricted")
+    private ConfigurationSource configurationSource;
+
+    @InjectMockComponents
+    private IsolatedExecutionConfiguration isolatedExecutionConfiguration;
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void isExecutionIsolated(boolean executionIsolated)
+    {
+        when(this.configurationSource.getProperty(anyString(), any(Boolean.class))).thenReturn(executionIsolated);
+
+        String macroId = "test";
+        assertEquals(executionIsolated, this.isolatedExecutionConfiguration.isExecutionIsolated(macroId));
+
+        verify(this.configurationSource).getProperty("rendering.macro.test.executionIsolated", Boolean.FALSE);
+
+        // Verify that on the second load the value is cached.
+        assertEquals(executionIsolated, this.isolatedExecutionConfiguration.isExecutionIsolated(macroId));
+
+        verifyNoMoreInteractions(this.configurationSource);
+
+        // Verify that the cached value doesn't affect a second macro ID.
+        String secondMacroId = "second";
+        when(this.configurationSource.getProperty("rendering.macro.second.executionIsolated", Boolean.FALSE))
+            .thenReturn(!executionIsolated);
+        assertEquals(!executionIsolated, this.isolatedExecutionConfiguration.isExecutionIsolated(secondMacroId));
+    }
+}

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformationTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformationTest.java
@@ -34,6 +34,7 @@ import org.mockito.stubbing.Answer;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.renderer.BlockRenderer;
 import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
@@ -213,6 +214,75 @@ class MacroTransformationTest
         BlockRenderer eventBlockRenderer =
             this.componentManager.getInstance(BlockRenderer.class, Syntax.EVENT_1_0.toIdString());
         eventBlockRenderer.render(dom, printer);
+        assertEquals(expected, printer.toString());
+    }
+
+    @Test
+    void transformWithSeveralNestedMacros() throws Exception
+    {
+        String expected = """
+            beginDocument
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro1]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            beginMacroMarkerStandalone [testprioritymacro] []
+            beginParagraph
+            onWord [word]
+            endParagraph
+            endMacroMarkerStandalone [testprioritymacro] []
+            beginMacroMarkerStandalone [testnestedmacro] []
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro2]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            endMacroMarkerStandalone [testnestedmacro] []
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro3]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            beginMacroMarkerStandalone [testtwonestedmacros] []
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro4]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            beginMacroMarkerStandalone [testnestedmacro] []
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro5]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            endMacroMarkerStandalone [testnestedmacro] []
+            endMacroMarkerStandalone [testtwonestedmacros] []
+            beginMacroMarkerStandalone [testsimplemacro] []
+            beginParagraph
+            onWord [simplemacro6]
+            endParagraph
+            endMacroMarkerStandalone [testsimplemacro] []
+            endDocument""";
+        XDOM dom = new XDOM(List.of(
+            new MacroBlock("testsimplemacro", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testprioritymacro", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testnestedmacro", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testsimplemacro", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testtwonestedmacros", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testsimplemacro", Listener.EMPTY_PARAMETERS, false)
+        ));
+
+        this.transformation.transform(dom, new
+
+            TransformationContext(dom, Syntax.XWIKI_2_0));
+
+        WikiPrinter printer = new DefaultWikiPrinter();
+
+        BlockRenderer eventBlockRenderer =
+            this.componentManager.getInstance(BlockRenderer.class, Syntax.EVENT_1_0.toIdString());
+        eventBlockRenderer.render(dom, printer);
+
         assertEquals(expected, printer.toString());
     }
 

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestNestedMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestNestedMacro.java
@@ -58,4 +58,10 @@ public class TestNestedMacro extends AbstractNoParameterMacro
         return Arrays.asList((Block) new MacroBlock("testsimplemacro", Collections.<String, String>emptyMap(),
             false));
     }
+
+    @Override
+    public boolean isExecutionIsolated(Object parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestPriorityMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestPriorityMacro.java
@@ -58,4 +58,10 @@ public class TestPriorityMacro extends AbstractNoParameterMacro
     {
         return Arrays.<Block>asList(new ParagraphBlock(Arrays.<Block>asList(new WordBlock("word"))));
     }
+
+    @Override
+    public boolean isExecutionIsolated(Object parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestRecursiveMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestRecursiveMacro.java
@@ -56,4 +56,10 @@ public class TestRecursiveMacro extends AbstractNoParameterMacro
         return Arrays.asList((Block) new MacroBlock("testrecursivemacro", Collections
             .<String, String>emptyMap(), false));
     }
+
+    @Override
+    public boolean isExecutionIsolated(Object parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestReplacementMacro.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestReplacementMacro.java
@@ -69,4 +69,10 @@ public class TestReplacementMacro extends AbstractMacro<TestMacroParameter>
         String parameter1 = parameters.getParam1();
         return List.of(new WordBlock(NAME), new WordBlock(content), new WordBlock(parameter1));
     }
+
+    @Override
+    public boolean isExecutionIsolated(TestMacroParameter parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestTwoNestedMacros.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/TestTwoNestedMacros.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.rendering.internal.transformation.macro;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Named;
@@ -27,21 +26,20 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.block.Block;
-import org.xwiki.rendering.block.ParagraphBlock;
-import org.xwiki.rendering.block.WordBlock;
-import org.xwiki.rendering.block.match.ClassBlockMatcher;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.listener.Listener;
 import org.xwiki.rendering.macro.AbstractNoParameterMacro;
 import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 
 @Component
-@Named("testsimplemacro")
+@Named("testtwonestedmacros")
 @Singleton
-public class TestSimpleMacro extends AbstractNoParameterMacro
+public class TestTwoNestedMacros extends AbstractNoParameterMacro
 {
-    public TestSimpleMacro()
+    public TestTwoNestedMacros()
     {
-        super("Simple Macro");
+        super("Two Nested Macros");
     }
 
     @Override
@@ -54,10 +52,8 @@ public class TestSimpleMacro extends AbstractNoParameterMacro
     public List<Block> execute(Object parameters, String content, MacroTransformationContext context)
         throws MacroExecutionException
     {
-        int wordCount = context.getXDOM().getBlocks(
-            new ClassBlockMatcher(WordBlock.class), Block.Axes.DESCENDANT).size();
-        return Arrays.<Block>asList(new ParagraphBlock(Arrays.<Block>asList(new WordBlock("simplemacro"
-            + wordCount))));
+        return List.of(new MacroBlock("testsimplemacro", Listener.EMPTY_PARAMETERS, false),
+            new MacroBlock("testnestedmacro", Listener.EMPTY_PARAMETERS, false));
     }
 
     @Override

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/resources/META-INF/components.txt
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/resources/META-INF/components.txt
@@ -10,3 +10,4 @@ org.xwiki.rendering.internal.transformation.macro.TestInlineEditingMacro
 org.xwiki.rendering.internal.transformation.macro.TestReplaceMeMacro
 org.xwiki.rendering.internal.transformation.macro.TestReplacementMacro
 org.xwiki.rendering.internal.transformation.macro.TestSyntaxWikiMacro
+org.xwiki.rendering.internal.transformation.macro.TestTwoNestedMacros


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-778

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduce the concept of isolated macros.
* In the macro transformation, use a priority queue to efficiently process macros in order.
* Don't re-scan the XDOM after executing isolated macros.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This introduces a slight overhead if no macros are isolated. For 5k macros without skin, the overhead seems around 12.16%, so it adds about 14% of execution time in this case. The overhead only depends on the number of macros being in the XDOM not yet executed at the same time, so I think having 5k macros at the top level without any other content is kind of the worst case in terms of overhead.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests,standalone
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None for now, seems a bit dangerous.