### PR TITLE
XCOMMONS-1258: Allow parameters of rendering macro developed in Java to be ordered

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/DefaultParameterDescriptor.java
@@ -126,4 +126,10 @@ public class DefaultParameterDescriptor implements ParameterDescriptor
     {
         return this.propertyDescriptor.isDisplayHidden();
     }
+
+    @Override
+    public int getOrder()
+    {
+        return this.propertyDescriptor.getOrder();
+    }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/macro/descriptor/ParameterDescriptor.java
@@ -22,6 +22,7 @@ package org.xwiki.rendering.macro.descriptor;
 import java.lang.reflect.Type;
 
 import org.xwiki.properties.PropertyGroupDescriptor;
+import org.xwiki.stability.Unstable;
 
 /**
  * Define a macro parameter.
@@ -116,5 +117,16 @@ public interface ParameterDescriptor
     default boolean isDisplayHidden()
     {
         return false;
+    }
+
+    /**
+     * @return the ordering value to use to display the property in the UI. The lower the value, the higher the
+     * priority. {@code -1} means no defined order.
+     * @since 17.5.0RC1
+     */
+    @Unstable
+    default int getOrder()
+    {
+        return -1;
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-1258

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Expose the getOrder API introduced in commons in ParameterDescriptor
* :warning: this PR should be merged after https://github.com/xwiki/xwiki-commons/pull/1330

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on the edited module

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None