### PR TITLE
Under some conditions, table characters ("|" and "!!") are not escaped at the beginning of a line in cells

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
@@ -43,6 +43,8 @@ public class XWikiSyntaxEscapeHandler
 
     private static final Pattern TABLE_PATTERN = Pattern.compile("\\p{Blank}*(\\||!!|!=)");
 
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\(%(?:~.|[^%~]|%[^)~]|%~.)*+%\\)");
+
     /**
      * Note that we take care to not match if the first character is preceded by an escape (i.e. '~).
      */
@@ -64,7 +66,7 @@ public class XWikiSyntaxEscapeHandler
     }
 
     public void escape(StringBuffer accumulatedBuffer, XWikiSyntaxListenerChain listenerChain, boolean escapeLastChar,
-        Pattern escapeFirstIfMatching)
+        Pattern escapeFirstIfMatching, String lastPrinted)
     {
         BlockStateChainingListener blockStateListener = listenerChain.getBlockStateChainingListener();
 
@@ -90,6 +92,12 @@ public class XWikiSyntaxEscapeHandler
 
             // Look for quote pattern at beginning of line and escape the first character only (it's enough)
             escapeFirstMatchedCharacter(QUOTE_PATTERN, accumulatedBuffer);
+        } else if (blockStateListener.isInLine() && lastPrinted != null
+            && PARAMETER_PATTERN.matcher(lastPrinted).matches())
+        {
+            // TODO: this might be escaping too much, we would only need to add the escaping when the parameters are at
+            //  the start of the line.
+            escapeFirstMatchedCharacter(TABLE_PATTERN, accumulatedBuffer);
         }
 
         // Escape table characters

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
@@ -43,6 +43,7 @@ public class XWikiSyntaxEscapeHandler
 
     private static final Pattern TABLE_PATTERN = Pattern.compile("\\p{Blank}*(\\||!!|!=)");
 
+    // This pattern closely follows the JavaCC grammar for parameters.
     private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\(%(?:~.|[^%~]|%[^)~]|%~.)*+%\\)");
 
     /**

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeWikiPrinter.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeWikiPrinter.java
@@ -91,7 +91,8 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
     public void flush()
     {
         if (getBuffer().length() > 0) {
-            this.escapeHandler.escape(getBuffer(), this.listenerChain, this.escapeLastChar, this.escapeFirstIfMatching);
+            this.escapeHandler.escape(getBuffer(), this.listenerChain, this.escapeLastChar, this.escapeFirstIfMatching,
+                this.lastPrinted);
             super.flush();
         }
         this.escapeLastChar = false;

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/table/table3.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/resources/xwiki20/specific/table/table3.test
@@ -1,0 +1,35 @@
+.#-------------------------------------------------------------------------------------------------------
+.inputexpect|xwiki/2.0
+.# XRENDERING-786 - Test that tables with parameters are properly escaped at the beginning of a line.
+.#-------------------------------------------------------------------------------------------------------
+|(((
+(% style="color: rgb(6,125,23);" %)hello
+(%%)~!!!! same cell
+)))
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginTable
+beginTableRow
+beginTableCell
+beginGroup
+beginParagraph
+beginFormat [NONE] [[style]=[color: rgb(6,125,23);]]
+onWord [hello]
+onNewLine
+endFormat [NONE] [[style]=[color: rgb(6,125,23);]]
+onSpecialSymbol [!]
+onSpecialSymbol [!]
+onSpecialSymbol [!]
+onSpecialSymbol [!]
+onSpace
+onWord [same]
+onSpace
+onWord [cell]
+endParagraph
+endGroup
+endTableCell
+endTableRow
+endTable
+endDocument


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-786

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Escape table syntax when the last printed characters are a parameter syntax.
* Add a test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This escapes too much. It would probably be possible to accumulate more data, like to store the text printed since the last newline. However, I'm not sure if it's worth the effort compared to the rare case of a removed escaping character.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

In `xwiki-rendering`:
```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,standalone
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x