### PR TITLE
XRENDERING-572: "wikiinternallink" is duplicated at every edit in CKeditor

### DIFF
--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/pom.xml
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/pom.xml
@@ -92,7 +92,6 @@
                 org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiReferenceTagHandler.java,
                 org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiCommentHandler.java,
                 org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiHeaderTagHandler.java,
-                org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiSpanTagHandler.java,
                 org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiXMLReaderFactory.java,
                 org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiWikiReference.java,
                 org/xwiki/rendering/internal/renderer/xhtml/link/DefaultXHTMLLinkRenderer.java,

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiSpanTagHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiSpanTagHandler.java
@@ -19,12 +19,19 @@
  */
 package org.xwiki.rendering.internal.parser.xhtml.wikimodel;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.rendering.internal.parser.xhtml.XHTMLParser;
 import org.xwiki.rendering.wikimodel.WikiParameter;
 import org.xwiki.rendering.wikimodel.WikiParameters;
 import org.xwiki.rendering.wikimodel.xhtml.handler.SpanTagHandler;
 import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
+
+import static java.util.function.Predicate.not;
 
 /**
  * Handle XWiki span elements (we need to ensure we skip link content when we generate them and also skip the spans for
@@ -35,6 +42,19 @@ import org.xwiki.rendering.wikimodel.xhtml.impl.TagContext;
  */
 public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiModelHandler
 {
+    private static final Set<String> IGNORED_CLASSES = Set.of(
+        "wikilink",
+        "wikiinternallink",
+        "wikicreatelink",
+        "wikiexternallink",
+        "wikiattachmentlink"
+    );
+
+    private static final String CLASS_ATTRIBUTE = "class";
+
+    private static final String WIKI_GENERATED_LINK_CONTENT = "wikigeneratedlinkcontent";
+
+    private static final String XWIKI_RENDERING_ERROR = "xwikirenderingerror";
 
     private XWikiMacroHandler xWikiMacroHandler;
 
@@ -60,22 +80,23 @@ public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiMode
         if (!withNonGeneratedContent) {
             // If we're on a span for unknown links then skip the event for its content.
             // Ex: <a href="..."><span class="wikicreatelinktext">...</span><span class="wikicreatelinkqm">?</span></a>
-            WikiParameter classParam = params.getParameter("class");
+            WikiParameter classParam = params.getParameter(CLASS_ATTRIBUTE);
             if (classParam != null) {
                 String classParamValue = classParam.getValue();
-                if (classParamValue.contains("wikigeneratedlinkcontent"))
+
+                String filteredClassNames = filterIgnoredClasses(classParamValue);
+                if (classParamValue.contains(WIKI_GENERATED_LINK_CONTENT)
+                    || XWIKI_RENDERING_ERROR.equals(classParamValue))
                 {
                     setAccumulateContent(true);
-                } else if ("wikilink".equals(classParamValue)
-                    || "wikicreatelink".equals(classParamValue)
-                    || "wikiexternallink".equals(classParamValue)
-                    || "wikiattachmentlink".equals(classParamValue))
-                {
-                    // Nothing to do
-                } else if ("xwikirenderingerror".equals(classParamValue)) {
-                    setAccumulateContent(true);
-                } else {
+                } else if (filteredClassNames.equals(classParamValue)) {
+                    // Nothing removed means not an ignored class.
                     super.begin(context);
+                } else if (!filteredClassNames.isEmpty()) {
+                    // There was something removed, but the class still isn't empty - most likely due to some bug, an
+                    // intended class was combined with an ignored class.
+                    // Keep the filtered class.
+                    super.begin(updateContext(context, filteredClassNames));
                 }
             } else {
                 super.begin(context);
@@ -89,26 +110,50 @@ public class XWikiSpanTagHandler extends SpanTagHandler implements XWikiWikiMode
         boolean nonGeneratedContent = this.xWikiMacroHandler.handleEnd(context);
 
         if (!nonGeneratedContent) {
-            WikiParameter classParam = context.getParams().getParameter("class");
+            WikiParameter classParam = context.getParams().getParameter(CLASS_ATTRIBUTE);
             if (classParam != null) {
                 String classParamValue = classParam.getValue();
-                if (classParamValue.contains("wikigeneratedlinkcontent"))
+
+                String filteredClassNames = filterIgnoredClasses(classParamValue);
+                if (classParamValue.contains(WIKI_GENERATED_LINK_CONTENT)
+                    || XWIKI_RENDERING_ERROR.equals(classParamValue))
                 {
                     setAccumulateContent(false);
-                } else if ("wikilink".equals(classParamValue)
-                    || "wikicreatelink".equals(classParamValue)
-                    || "wikiexternallink".equals(classParamValue)
-                    || "wikiattachmentlink".equals(classParamValue))
-                {
-                    // Nothing to do
-                } else if ("xwikirenderingerror".equals(classParamValue)) {
-                    setAccumulateContent(false);
-                } else {
+                } else if (filteredClassNames.equals(classParamValue)) {
+                    // Nothing removed means not an ignored class.
                     super.end(context);
+                } else if (!filteredClassNames.isEmpty()) {
+                    // There was something removed, but the class still isn't empty - most likely due to some bug, an
+                    // intended class was combined with an ignored class.
+                    // Keep the filtered class.
+                    super.end(updateContext(context, filteredClassNames));
                 }
             } else {
                 super.end(context);
             }
         }
+    }
+
+    private static TagContext updateContext(TagContext context, String filteredClassNames)
+    {
+        // We cannot update parameters or context, so create a new context.
+        WikiParameters updatedParameters = context.getParams().setParameter(CLASS_ATTRIBUTE, filteredClassNames);
+        return new TagContext(context.getParentContext(), context.getName(), updatedParameters, context.getTagStack());
+    }
+
+    private static String filterIgnoredClasses(String classParamValue)
+    {
+        String[] classes = StringUtils.split(classParamValue);
+        String filteredClassNames;
+        if (Arrays.stream(classes).anyMatch(IGNORED_CLASSES::contains)) {
+            filteredClassNames = Arrays.stream(classes)
+                .filter(not(IGNORED_CLASSES::contains))
+                .collect(Collectors.joining(" "));
+        } else {
+            // Keep the exact original string such that it is easy to check if anything has been removed and to avoid
+            // modifications that could, e.g., lead to non-empty diffs even though nothing has been changed.
+            filteredClassNames = classParamValue;
+        }
+        return filteredClassNames;
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/link/link9.test
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/test/resources/xhtml10/specific/link/link9.test
@@ -1,0 +1,38 @@
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.# Formatting inside links. Also verify that when classes are combined due a bug, the ignored class is removed again.
+.#-----------------------------------------------------
+<p><!--startwikilink:true|-|path|-|/bin/view/Page--><span class="wikiinternallink"><a href="/bin/view/Page"><span
+class="test">Page</span></a></span><!--stopwikilink--></p>
+<p><!--startwikilink:true|-|path|-|/bin/view/Page--><span class="wikiinternallink"><a href="/bin/view/Page"><span
+class="test wikiinternallink ">Page</span></a></span><!--stopwikilink--></p>
+<p><!--startwikilink:true|-|path|-|/bin/view/Page--><span class="wikiinternallink"><a href="/bin/view/Page"
+>Page</a></span><!--stopwikilink--></p>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+beginLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+beginFormat [NONE] [[class]=[test]]
+onWord [Page]
+endFormat [NONE] [[class]=[test]]
+endLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+endParagraph
+beginParagraph
+beginLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+beginFormat [NONE] [[class]=[test]]
+onWord [Page]
+endFormat [NONE] [[class]=[test]]
+endLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+endParagraph
+beginParagraph
+beginLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+onWord [Page]
+endLink [Typed = [true] Type = [path] Reference = [/bin/view/Page]] [false]
+endParagraph
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<p><span class="wikiinternallink"><a href="/bin/view/Page"><span class="test">Page</span></a></span></p><p><span class="wikiinternallink"><a href="/bin/view/Page"><span class="test">Page</span></a></span></p><p><span class="wikiinternallink"><a href="/bin/view/Page">Page</a></span></p>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-572

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add wikiinternallink to the classes to remove.
* Improve the class removal to work when the class to remove appears several times or in combination with other classes to ensure a proper cleanup the next time the WYSIWYG editor is used.
* Add a test to verify that the class is removed as intended.
* Improve the code style and remove the Checkstyle exclusion.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The diff might not make this fully clear, but basically we have a set of classes that are produced by the link renderer, all of them being properly removed but `wikiinternallink` which was somehow missing from the list. So the main fix is also removing `wikiinternallink`, but then I added all the extra code to ensure that we're also handling the mess that was created by this bug.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

In `xwiki-rendering`:
```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,standalone
```


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x