### PR TITLE
XRENDERING-798: Line breaks followed by empty format at the end of block elements should be escaped

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/misc/misc7.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/misc/misc7.test
@@ -24,6 +24,10 @@ paragraph1\\
 paragraph2
 
 [[Caption\\>>image:img.png]]
+
+(% border="1" %)
+|var|(%%)(% style="color: #0000ff;" %)asdf\\
+|bar|function
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
@@ -105,5 +109,26 @@ onNewLine
 endParagraph
 endFigureCaption
 endFigure [[class]=[image]]
+beginTable [[border]=[1]]
+beginTableRow
+beginTableCell
+onWord [var]
+endTableCell
+beginTableCell
+beginFormat [NONE] [[style]=[color: #0000ff;]]
+onWord [asdf]
+onNewLine
+endFormat [NONE] [[style]=[color: #0000ff;]]
+endTableCell
+endTableRow
+beginTableRow
+beginTableCell
+onWord [bar]
+endTableCell
+beginTableCell
+onWord [function]
+endTableCell
+endTableRow
+endTable [[border]=[1]]
 endSection
 endDocument

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -355,12 +355,21 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
         if (getBlockState().isInLine()) {
             if (getXWikiSyntaxListenerChain().getConsecutiveNewLineStateChainingListener().getNewLineCount() > 1) {
                 print("\\\\");
-            } else if (getXWikiSyntaxListenerChain().getLookaheadChainingListener().getNextEvent().eventType
-                .isInlineEnd())
-            {
-                print("\\\\");
             } else {
-                print("\n");
+                LookaheadChainingListener lookaheadListener =
+                    getXWikiSyntaxListenerChain().getLookaheadChainingListener();
+                QueueListener.Event nextEvent = lookaheadListener.getNextEvent();
+                if (nextEvent.eventType.isInlineEnd()
+                    // Format end events don't print anything for the none format at the end of inline elements as
+                    // the format is automatically reset. So consider that we're already at the end of an inline
+                    // element in that case.
+                    || (nextEvent.eventType == EventType.END_FORMAT && nextEvent.eventParameters[0] == Format.NONE
+                    && lookaheadListener.getNextEvent(2).eventType.isInlineEnd()))
+                {
+                    print("\\\\");
+                } else {
+                    print("\n");
+                }
             }
         } else {
             print("\n");


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-798

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Check for empty format to decide what syntax to use for new lines.
* Extend integration test to cover this case.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This seems to be the first time that a look ahead of 2 is used - but from what I can see, we have the look ahead listener configured with depth 2, so this should be okay.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the full `xwiki-rendering` with quality profile:
```
mvn clean install -Pquality,standalone,legacy
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x
  * stable-16.10.x