### PR TITLE
[Misc] Migrate to the OSS Community Develocity Instance

### DIFF
--- a/.mvn/develocity-custom-user-data.groovy
+++ b/.mvn/develocity-custom-user-data.groovy
@@ -21,7 +21,7 @@ import com.gradle.develocity.agent.maven.adapters.BuildScanApiAdapter
 
 /**
  * Captures the Maven active profiles and add them as tags to the Build Scan. The goal is to make it simpler to
- * filter builds on <a href="ge.xwiki.org">https://ge.xwiki.org</a> by filtering on Maven profiles.
+ * filter builds on <a href="https://community.develocity.cloud/scans?search.rootProjectNames=XWiki*">https://community.develocity.cloud</a> by filtering on Maven profiles.
  */
 
 buildScan.executeOnce('tag-profiles') { BuildScanApiAdapter buildScanApi ->

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -24,11 +24,13 @@
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
   <server>
-    <url>https://ge.xwiki.org</url>
+    <url>https://community.develocity.cloud</url>
   </server>
+  <projectId>xwiki</projectId>
   <buildScan>
-    <!-- Always publish build scans on CI but on demand for devs so that we don't get false positives on ge.xwiki.org
-     due to local changes from users and so that it doesn't pollute the ge.xwiki.org data.
+    <!-- Always publish build scans on CI but on demand for devs so that we don't get false positives on
+     community.develocity.cloud due to local changes from users and so that it doesn't pollute the
+     community.develocity.cloud data.
      To force publishing a build scan: -Dscan -->
     <publishing>
       <onlyIf><![CDATA[env['CI'] != null && authenticated]]></onlyIf>
@@ -54,14 +56,8 @@
       <enabled>true</enabled>
       <!-- Only CI jobs are allowed to store build outputs in the remote cache -->
       <storeEnabled>#{env['CI'] != null}</storeEnabled>
-      <server>
-        <!-- Note: Remote cache authentication is handled in the .m2/.develocity/keys.properties file and not
-             anymore in the Maven settings.xml file -->
-        <id>develocityCache</id>
-        <!-- We override the default built-in node to use a EU node closer to our CI to reduce the cache lag (and thus
-             to make caching more beneficial vs rebuilding) -->
-        <url>https://eu-build-cache-ge.xwiki.org/cache/</url>
-      </server>
+      <!-- Note: Remote cache authentication is handled in the .m2/.develocity/keys.properties file and not
+           anymore in the Maven settings.xml file -->
     </remote>
   </buildCache>
 </develocity>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read our [Release Notes](http://www.xwiki.org/xwiki/bin/view/ReleaseNotes/).
 * [Continuous Integration](http://ci.xwiki.org/) setup launches a build for each commit
 * [Issue Tracker](http://jira.xwiki.org/browse/XRENDERING) if you want to report an issue
 * [Development Flow](http://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HGeneralDevelopmentFlow) to see the full list of tools we use to build XWiki
-* [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.xwiki.org/scans)
+* [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=XWiki*)
 
 ## Project Statistics
 


### PR DESCRIPTION
This PR migrates this repository's [Develocity](https://gradle.com/develocity)
Build Scan® and Build Cache configuration from `https://ge.xwiki.org` to the
**OSS Community Develocity Instance** at <https://community.develocity.cloud>,
under project ID `xwiki`.

## What this PR changes

- Build Scan publishing and remote Build Cache traffic are redirected from
  `ge.xwiki.org` to `community.develocity.cloud`, scoped to project `xwiki`.
- The dedicated EU Build Cache Node is no longer referenced. The remote cache
  talks directly to the main instance (see below).
- The README badge and the doc-comment in the custom-user-data script are
  updated to point at the new instance.
- The Develocity Maven extension version and the `tag-profiles`
  custom-user-data logic are unchanged.

## Note on `eu-build-cache-ge.xwiki.org`

The dedicated XWiki Build Cache Node (BCN) at `eu-build-cache-ge.xwiki.org` is
being decommissioned as part of this move. The OSS Community Develocity
Instance is itself hosted in the EU, so a separate regional cache node in front
of it is no longer necessary, and the remote cache falls back to the main
Develocity server URL.

## Step 1: Generate an access key for the CI account on `community.develocity.cloud`

The Develocity Maven extension on the Jenkins agents authenticates with an
access key. The current key for `ge.xwiki.org` will stop working after this
PR merges, so a new one for `community.develocity.cloud` needs to be issued.

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions team has
   provisioned for the XWiki project.** That account was shared with the XWiki
   maintainers out of band; the access key inherits that account's project
   memberships and permissions, which is what is needed for CI.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `XWiki Jenkins`),
   and copy the generated key. Keep this tab open until you complete Step 2.
   The key is only shown once.

## Step 2: Replace the access key where it is set today

The new access key needs to replace the existing `ge.xwiki.org=<old-key>`
where it is currently set, in the form your CI uses to inject it: a
`keys.properties` file on each build agent, a `DEVELOCITY_ACCESS_KEY`
environment variable, a GitHub Actions repository secret, or similar. The
[Develocity Maven extension docs](https://docs.gradle.com/develocity/maven-extension/current/#manual-access-key-configuration)
describe the supported options.

For this repository specifically, the key appears to be read from
`~/.m2/.develocity/keys.properties` on the Jenkins build agents. The
`Jenkinsfile` and the shared `xwiki-jenkins-pipeline` library do not wire the
key any other way. On each Jenkins build agent that runs Maven builds:

1. Open `~/.m2/.develocity/keys.properties`.
2. Remove (or comment out) the existing `ge.xwiki.org=<old-key>` line.
3. Add a new line in the form:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required**. Without the host
   name, the access key is silently ignored. This is the most common point of
   failure when onboarding, so please double-check the format.

## Step 3: Provision an access key for your local builds

Developers building this project locally should provision their own access key
for `community.develocity.cloud` so their Build Scans publish and they get
reads from the remote Build Cache. The Develocity Maven extension's
`provision-access-key` goal does this in a single command. It opens the
browser, asks the developer to confirm, and writes the key to
`~/.m2/.develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in
your browser (or use a private/incognito window) so the access key gets
associated with **your personal account**, not the CI service account from
Step 1.

```
mvn com.gradle:develocity-maven-extension:1.23.3:provision-access-key -Ddevelocity.url=https://community.develocity.cloud
```

## What to expect

Once Steps 1 and 2 are done and this PR is merged, every Jenkins build of this
repository will publish a Build Scan to <https://community.develocity.cloud>
under project `xwiki` and read from / write to the remote Build Cache served
by that same instance. Your projects' caching is configured to be isolated from
other projects (via the `xwiki` project ID and Project-Level Access Control).
Only your CI user's access key is authorized to write such entries and your
builds will only read those entries.