### PR TITLE
[Misc] Use isEmpty() instead of comparing length() to zero

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/renderer/ParametersPrinter.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/renderer/ParametersPrinter.java
@@ -128,7 +128,7 @@ public class ParametersPrinter
             String key = entry.getKey();
 
             if (key != null && value != null) {
-                if (builder.length() > 0) {
+                if (!builder.isEmpty()) {
                     builder.append(' ');
                 }
                 builder.append(print(key, value));

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/renderer/printer/LookaheadWikiPrinter.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/renderer/printer/LookaheadWikiPrinter.java
@@ -98,7 +98,7 @@ public class LookaheadWikiPrinter extends WrappingWikiPrinter
      */
     public void flush()
     {
-        if (getBuffer().length() > 0) {
+        if (!getBuffer().isEmpty()) {
             printInternal(getBuffer().toString());
             getBuffer().setLength(0);
         }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-event/src/main/java/org/xwiki/rendering/internal/renderer/event/EventsChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-event/src/main/java/org/xwiki/rendering/internal/renderer/event/EventsChainingRenderer.java
@@ -533,7 +533,7 @@ public class EventsChainingRenderer extends AbstractChainingPrintRenderer
             }
         }
 
-        if (parametersStr.length() > 0) {
+        if (!parametersStr.isEmpty()) {
             StringBuilder buffer = new StringBuilder();
             buffer.append(' ').append('[');
             buffer.append(parametersStr);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/DefaultBlockParser.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xdomxml10/src/main/java/org/xwiki/rendering/xdomxml10/internal/parser/DefaultBlockParser.java
@@ -134,7 +134,7 @@ public class DefaultBlockParser extends AbstractBlockParser
     {
         String str = getParameters().get(name);
 
-        return str != null && str.length() > 0 ? str.charAt(0) : defaultValue;
+        return str != null && !str.isEmpty() ? str.charAt(0) : defaultValue;
     }
 
     /**

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiXHTMLWhitespaceXMLFilter.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/parser/xhtml/wikimodel/XWikiXHTMLWhitespaceXMLFilter.java
@@ -76,7 +76,7 @@ public class XWikiXHTMLWhitespaceXMLFilter extends XHTMLWhitespaceXMLFilter
     @Override
     public void endCDATA() throws SAXException
     {
-        if (getContent().length() > 0 && this.containsWikiSyntax) {
+        if (!getContent().isEmpty() && this.containsWikiSyntax) {
             // Make sure we clean head/trail white spaces
             trimLeadingWhiteSpaces();
             trimTrailingWhiteSpaces();
@@ -97,7 +97,7 @@ public class XWikiXHTMLWhitespaceXMLFilter extends XHTMLWhitespaceXMLFilter
     {
         // If the element texts can contain wiki syntax only clean whitespaces at beginning and end of texts.
         if (this.containsWikiSyntax) {
-            if (getContent().length() > 0) {
+            if (!getContent().isEmpty()) {
                 Matcher matcher = HTML_WHITESPACE_BOUNDARIES_PATTERN.matcher(getContent());
                 String result = matcher.replaceAll(" ");
                 getContent().setLength(0);

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/link/AbstractXHTMLLinkTypeRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/link/AbstractXHTMLLinkTypeRenderer.java
@@ -241,7 +241,7 @@ public abstract class AbstractXHTMLLinkTypeRenderer implements XHTMLLinkTypeRend
     private String addAttributeValue(String currentValue, String valueToAdd)
     {
         String newValue;
-        if (currentValue == null || currentValue.length() == 0) {
+        if (currentValue == null || currentValue.isEmpty()) {
             newValue = "";
         } else {
             newValue = currentValue + " ";

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -197,7 +197,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
         // Flush text content before the link.
         // Escape open link syntax when before a link.
         if (getLinkRenderer().forceFullSyntax(getXWikiPrinter(), freestanding, parameters)
-            && getXWikiPrinter().getBuffer().length() > 0
+            && !getXWikiPrinter().getBuffer().isEmpty()
             && getXWikiPrinter().getBuffer().charAt(getXWikiPrinter().getBuffer().length() - 1) == '[')
         {
             getXWikiPrinter().setEscapeLastChar(true);
@@ -621,7 +621,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
             getPrinter().print("\n");
         }
 
-        if (this.listStyle.length() > 0) {
+        if (!this.listStyle.isEmpty()) {
             print(this.listStyle.toString());
             if (this.listStyle.charAt(0) == '1') {
                 print(".");
@@ -643,7 +643,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
             getPrinter().print("\n");
         }
 
-        if (this.listStyle.length() > 0) {
+        if (!this.listStyle.isEmpty()) {
             print(this.listStyle.toString());
             if (this.listStyle.charAt(0) == '1') {
                 print(".");
@@ -937,7 +937,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
             }
         }
 
-        if (parametersStr.length() > 0) {
+        if (!parametersStr.isEmpty()) {
             StringBuilder buffer = new StringBuilder("(%");
             buffer.append(parametersStr);
             buffer.append(" %)");

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeWikiPrinter.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeWikiPrinter.java
@@ -90,7 +90,7 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
     @Override
     public void flush()
     {
-        if (getBuffer().length() > 0) {
+        if (!getBuffer().isEmpty()) {
             this.escapeHandler.escape(getBuffer(), this.listenerChain, this.escapeLastChar, this.escapeFirstIfMatching,
                 this.lastPrinted);
             super.flush();
@@ -141,7 +141,7 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
     {
         // If the lookahead buffer is not empty and the last character is ":" then we need to escape it
         // since otherwise we would get "://" which could be confused for a URL.
-        if (getBuffer().length() > 0 && getBuffer().charAt(getBuffer().length() - 1) == ':') {
+        if (!getBuffer().isEmpty() && getBuffer().charAt(getBuffer().length() - 1) == ':') {
             this.escapeLastChar = true;
         }
 
@@ -152,7 +152,7 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
     {
         // If the lookahead buffer is not empty and the last character is ":" then we need to escape it
         // since otherwise we would get "://" which could be confused for a URL.
-        if (getBuffer().length() > 0 && getBuffer().charAt(getBuffer().length() - 1) == ':') {
+        if (!getBuffer().isEmpty() && getBuffer().charAt(getBuffer().length() - 1) == ':') {
             this.escapeLastChar = true;
         }
 
@@ -163,7 +163,7 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
     {
         // If the lookahead buffer is not empty and the last character is "{" then we need to escape it
         // since otherwise we would get "{{{" which could be confused for a verbatim block.
-        if (getBuffer().length() > 0 && getBuffer().charAt(getBuffer().length() - 1) == '{') {
+        if (!getBuffer().isEmpty() && getBuffer().charAt(getBuffer().length() - 1) == '{') {
             this.escapeLastChar = true;
         }
 
@@ -225,7 +225,7 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
         String end = verbatimContent.substring(currentIndex);
 
         if (printEndVerbatim) {
-            if (end.length() == 0 || end.charAt(0) == '}') {
+            if (end.isEmpty() || end.charAt(0) == '}') {
                 result.append("~}~}~}");
             } else {
                 result.append("~}}}");
@@ -241,14 +241,14 @@ public class XWikiSyntaxEscapeWikiPrinter extends LookaheadWikiPrinter
                 StringBuffer subVerbatim = subVerbatimStack.pop();
 
                 if (subVerbatimStack.isEmpty()) {
-                    if (subVerbatim.length() > 0 && subVerbatim.charAt(0) == '{') {
+                    if (!subVerbatim.isEmpty() && subVerbatim.charAt(0) == '{') {
                         result.append("~{~{~{");
                     } else {
                         result.append("~{{{");
                     }
                     result.append(subVerbatim);
                 } else {
-                    if (subVerbatim.length() > 0 && subVerbatim.charAt(0) == '{') {
+                    if (!subVerbatim.isEmpty() && subVerbatim.charAt(0) == '{') {
                         subVerbatimStack.peek().append("~{~{~{");
                     } else {
                         subVerbatimStack.peek().append("~{{{");

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxMacroRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxMacroRenderer.java
@@ -61,7 +61,7 @@ public class XWikiSyntaxMacroRenderer
             buffer.append("/}}");
         } else {
             buffer.append(CLOSING_MARKER);
-            if (content.length() > 0) {
+            if (!content.isEmpty()) {
                 if (!isInline) {
                     buffer.append('\n');
                 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/reference/XWikiSyntaxResourceRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/reference/XWikiSyntaxResourceRenderer.java
@@ -94,7 +94,7 @@ public class XWikiSyntaxResourceRenderer
     {
         // find if the last printed char is part of a syntax (i.e. consumed by the parser before starting to parse the
         // link)
-        boolean isLastSyntax = printer.getBuffer().length() == 0;
+        boolean isLastSyntax = printer.getBuffer().isEmpty();
 
         printer.flush();
 

--- a/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
+++ b/xwiki-rendering-test/src/main/java/org/xwiki/rendering/test/integration/TestDataParser.java
@@ -158,7 +158,7 @@ public class TestDataParser
     {
         // Remove the last newline since our test format forces an additional new lines
         // at the end of input texts.
-        if (buffer.length() > 0 && buffer.charAt(buffer.length() - 1) == '\n') {
+        if (!buffer.isEmpty() && buffer.charAt(buffer.length() - 1) == '\n') {
             buffer.setLength(buffer.length() - 1);
         }
         map.put(keyName, buffer.toString());

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/filter/AccumulationXMLFilter.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/filter/AccumulationXMLFilter.java
@@ -110,7 +110,7 @@ public class AccumulationXMLFilter extends DefaultXMLFilter
 
     private void flushAccumulationBuffer() throws SAXException
     {
-        if (fAccumulationBuffer.length() > 0) {
+        if (!fAccumulationBuffer.isEmpty()) {
             super.characters(
                 fAccumulationBuffer.toString().toCharArray(),
                 0,

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/filter/XHTMLWhitespaceXMLFilter.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/filter/XHTMLWhitespaceXMLFilter.java
@@ -278,7 +278,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     protected void sendPreviousContent(boolean trimTrailing)
         throws SAXException
     {
-        if (fPreviousContent != null && fPreviousContent.length() > 0) {
+        if (fPreviousContent != null && !fPreviousContent.isEmpty()) {
             if (trimTrailing) {
                 fPreviousContent = trimTrailingWhiteSpaces(fPreviousContent);
             }
@@ -329,10 +329,10 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
         }
 
         // Send previous content
-        sendPreviousContent(getContent().length() == 0);
+        sendPreviousContent(getContent().isEmpty());
 
         // Send current content
-        if (getContent().length() > 0) {
+        if (!getContent().isEmpty()) {
             sendCharacters(getContent().toString().toCharArray());
             getContent().setLength(0);
         }
@@ -350,7 +350,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
         cleanContentLeadingSpaces();
         cleanContentExtraWhiteSpaces();
 
-        if (getContent().length() > 0) {
+        if (!getContent().isEmpty()) {
             sendPreviousContent(false);
 
             fPreviousInlineText.append(getContent());
@@ -365,7 +365,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
 
             getContent().setLength(0);
         } else {
-            if (fPreviousInlineText.length() == 0) {
+            if (fPreviousInlineText.isEmpty()) {
                 // There is no inline text before this inline element
                 sendInlineEvent(event);
             } else {
@@ -396,7 +396,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     protected void endEmptyVisibleElement() throws SAXException
     {
         // Send current content
-        if (getContent().length() > 0) {
+        if (!getContent().isEmpty()) {
             sendCharacters(getContent().toString().toCharArray());
             getContent().setLength(0);
         }
@@ -411,7 +411,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
             cleanContentLeadingSpaces();
             cleanContentExtraWhiteSpaces();
 
-            if (getContent().length() > 0) {
+            if (!getContent().isEmpty()) {
                 sendPreviousContent(false);
 
                 fPreviousInlineText.append(getContent());
@@ -448,7 +448,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     protected void endNonVisibleElement() throws SAXException
     {
         // Send current content
-        if (getContent().length() > 0) {
+        if (!getContent().isEmpty()) {
             sendCharacters(getContent().toString().toCharArray());
             getContent().setLength(0);
         }
@@ -476,8 +476,8 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
      */
     private void cleanContentLeadingSpaces()
     {
-        if (getContent().length() > 0) {
-            if (fPreviousInlineText.length() == 0
+        if (!getContent().isEmpty()) {
+            if (fPreviousInlineText.isEmpty()
                 || fPreviousInlineText
                 .charAt(fPreviousInlineText.length() - 1) == ' ')
             {
@@ -491,7 +491,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
      */
     protected void cleanContentExtraWhiteSpaces()
     {
-        if (getContent().length() > 0) {
+        if (!getContent().isEmpty()) {
             if (shouldRemoveWhiteSpaces()) {
                 Matcher matcher = HTML_WHITESPACE_DUPLICATES_PATTERN
                     .matcher(getContent());
@@ -506,7 +506,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     // when in CDATA or PRE elements).
     protected void trimLeadingWhiteSpaces()
     {
-        if (shouldRemoveWhiteSpaces() && getContent().length() > 0) {
+        if (shouldRemoveWhiteSpaces() && !getContent().isEmpty()) {
             String result = trimLeadingWhiteSpaces(getContent());
             getContent().setLength(0);
             getContent().append(result);
@@ -517,7 +517,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     {
         String trimedContent;
 
-        if (shouldRemoveWhiteSpaces() && content.length() > 0) {
+        if (shouldRemoveWhiteSpaces() && !content.isEmpty()) {
             Matcher matcher = HTML_WHITESPACE_HEAD_PATTERN.matcher(content);
             trimedContent = matcher.replaceAll("");
         } else {
@@ -529,7 +529,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
 
     protected void trimTrailingWhiteSpaces()
     {
-        if (shouldRemoveWhiteSpaces() && getContent().length() > 0) {
+        if (shouldRemoveWhiteSpaces() && !getContent().isEmpty()) {
             String result = trimTrailingWhiteSpaces(getContent());
             getContent().setLength(0);
             getContent().append(result);
@@ -540,7 +540,7 @@ public class XHTMLWhitespaceXMLFilter extends DefaultXMLFilter
     {
         String trimedContent;
 
-        if (shouldRemoveWhiteSpaces() && content.length() > 0) {
+        if (shouldRemoveWhiteSpaces() && !content.isEmpty()) {
             Matcher matcher = HTML_WHITESPACE_TAIL_PATTERN.matcher(content);
             trimedContent = matcher.replaceAll("");
         } else {

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagStack.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xhtml/impl/TagStack.java
@@ -409,14 +409,14 @@ public class TagStack
         // We should always have a length greater than 0 but we handle
         // the case where the user has entered some badly formed HTML
         StringBuffer listStyles = (StringBuffer) getStackParameter(LIST_STYLES);
-        if (listStyles.length() > 0) {
+        if (!listStyles.isEmpty()) {
             listStyles.setLength(listStyles.length() - 1);
         }
     }
 
     public boolean isEndOfList()
     {
-        return ((StringBuffer) getStackParameter(LIST_STYLES)).length() == 0;
+        return ((StringBuffer) getStackParameter(LIST_STYLES)).isEmpty();
     }
 
     public void resetEmptyLinesCount()

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xwiki/xwiki20/XWikiReferenceParser.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/xwiki/xwiki20/XWikiReferenceParser.java
@@ -109,7 +109,7 @@ public class XWikiReferenceParser extends WikiReferenceParser
             chunks[1] = reference.toString();
         }
 
-        if (parameters.length() > 0) {
+        if (!parameters.isEmpty()) {
             chunks[2] = parameters.toString();
         }
 


### PR DESCRIPTION
## Summary

Fixes **40 SonarCloud issues** for rule [java:S7158](https://sonarcloud.io/project/issues?id=org.xwiki.rendering%3Axwiki-rendering&resolved=false&rules=java%3AS7158) — *"Use isEmpty() to check whether a StringBuilder is empty or not"* — across 15 files.

The transformation is purely mechanical, single-line and behaviour-neutral:

- `X.length() == 0` → `X.isEmpty()`
- `X.length() > 0` / `X.length() != 0` → `!X.isEmpty()`

`isEmpty()` is available on every receiver involved here (`String` since Java 6, `CharSequence` since Java 15, `StringBuilder`/`StringBuffer`), and XWiki targets Java 17. Only the flagged comparison is rewritten — surrounding clauses such as `buffer.charAt(buffer.length() - 1)` are left untouched. No signature, visibility or API change, so no backward-compatibility impact.

Modules touched: `xwiki-rendering-api`, `xwiki-rendering-test`, `xwiki-rendering-wikimodel`, and the `event` / `xdomxml10` / `xhtml` / `xwiki20` syntax modules. The bulk sits in the whitespace filters (`XHTMLWhitespaceXMLFilter`, `XWikiXHTMLWhitespaceXMLFilter`) and in `XWikiSyntaxEscapeWikiPrinter`.

## Test plan

- [x] `mvn clean install -Plegacy,quality` over all 7 modified modules — **BUILD SUCCESS** (Checkstyle, Spoon, Revapi, Enforcer and JaCoCo coverage gates included; full unit-test suites run, no failures).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEcsxtam1wCP6aLxwwbKbt)_