### PR TITLE
[Misc] Move the legacy module Revapi ignores to the root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,24 @@
                    </differences>
                  </revapi.differences>
             -->
-            
+            <revapi.differences>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeValueChanged</code>
+                  <old>method java.lang.String org.xwiki.rendering.macro.descriptor.MacroDescriptorAspect::aroundGetDefaultCategory(org.xwiki.rendering.macro.descriptor.MacroDescriptor)</old>
+                  <new>method java.lang.String org.xwiki.rendering.macro.descriptor.MacroDescriptorAspect::aroundGetDefaultCategory(org.xwiki.rendering.macro.descriptor.MacroDescriptor)</new>
+                  <annotationType>org.aspectj.lang.annotation.Around</annotationType>
+                  <attribute>value</attribute>
+                  <criticality>allowed</criticality>
+                  <justification>The pointcut of the legacy getDefaultCategory() advice now matches
+                    CompatibilityMacroDescriptor, which is where the method body lives, so that the advice is really
+                    weaved, and it excludes the advice's own control flow to avoid an infinite recursion with the
+                    getDefaultCategories() advice. The pointcut expression is an implementation detail of the aspect
+                    and not part of the public API.</justification>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/pom.xml
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/pom.xml
@@ -83,33 +83,6 @@
           </weaveDependencies>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.revapi</groupId>
-        <artifactId>revapi-maven-plugin</artifactId>
-        <configuration>
-          <analysisConfiguration>
-            <revapi.differences>
-              <!-- Append to the ignores defined in the top level pom instead of replacing them. -->
-              <differences combine.children="append">
-                <item>
-                  <ignore>true</ignore>
-                  <code>java.annotation.attributeValueChanged</code>
-                  <old>method java.lang.String org.xwiki.rendering.macro.descriptor.MacroDescriptorAspect::aroundGetDefaultCategory(org.xwiki.rendering.macro.descriptor.MacroDescriptor)</old>
-                  <new>method java.lang.String org.xwiki.rendering.macro.descriptor.MacroDescriptorAspect::aroundGetDefaultCategory(org.xwiki.rendering.macro.descriptor.MacroDescriptor)</new>
-                  <annotationType>org.aspectj.lang.annotation.Around</annotationType>
-                  <attribute>value</attribute>
-                  <criticality>allowed</criticality>
-                  <justification>The pointcut of the legacy getDefaultCategory() advice now matches
-                    CompatibilityMacroDescriptor, which is where the method body lives, so that the advice is really
-                    weaved, and it excludes the advice's own control flow to avoid an infinite recursion with the
-                    getDefaultCategories() advice. The pointcut expression is an implementation detail of the aspect
-                    and not part of the public API.</justification>
-                </item>
-              </differences>
-            </revapi.differences>
-          </analysisConfiguration>
-        </configuration>
-      </plugin>
       <!-- Exclude AspectJ's builddef.lst file form the generated JAR since it's not useful there. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (build configuration cleanup, no functional impact).

# Changes

## Description

* Move the only Revapi ignore that was declared in a legacy module to the root `pom.xml`, which is
  where xwiki-rendering keeps its Revapi ignores.
  The ignore concerns `MacroDescriptorAspect#aroundGetDefaultCategory`
  (`java.annotation.attributeValueChanged`) and was living in
  `xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro/pom.xml`.
* Remove the `revapi-maven-plugin` declaration from that module: the ignore was its only content, so
  the module now simply inherits the root configuration.

## Clarifications

* The `combine.children="append"` attribute (and its accompanying comment) is dropped along the way
  since it was only needed to append to the root pom ignores from a child pom.
* An audit of all the other legacy modules found no other Revapi ignore, so this PR moves everything
  there was to move.
* The ignore was verified to be load-bearing rather than stale: altering its `<code>` in the root pom
  makes `xwiki-rendering-legacy-transformation-macro` fail with the expected
  `java.annotation.attributeValueChanged` error on `aroundGetDefaultCategory`, and restoring it makes
  the build pass again. So the ignore is really picked up from the root pom by the legacy module.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* `mvn install -B -ntp -Plegacy,snapshot -pl xwiki-rendering-legacy/xwiki-rendering-legacy-transformations/xwiki-rendering-legacy-transformation-macro`
  → BUILD SUCCESS, `revapi:check` runs and passes, 10 tests pass.
* `mvn install -B -ntp -Psnapshot,legacy -DskipTests` (full reactor, to validate the inherited root
  Revapi configuration on every module) → BUILD SUCCESS.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
