### PR TITLE
[Misc] Fix logging best practices violations in the rendering modules

### DIFF
--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/reference/DefaultResourceReferenceParser.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/parser/reference/DefaultResourceReferenceParser.java
@@ -97,7 +97,7 @@ public class DefaultResourceReferenceParser extends AbstractResourceReferencePar
                         componentManager.getInstance(ResourceReferenceTypeParser.class, typePrefix);
                     parsedResourceReference = parser.parse(reference);
                 } catch (ComponentLookupException e) {
-                    this.logger.error("Failed to initialize resource type parser", e);
+                    this.logger.error("Failed to initialize the resource type parser for type [{}]", typePrefix, e);
                 }
             }
         }

--- a/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/transformation/RenderingContextStore.java
+++ b/xwiki-rendering-api/src/main/java/org/xwiki/rendering/internal/transformation/RenderingContextStore.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.internal.concurrent.AbstractContextStore;
@@ -125,7 +126,8 @@ public class RenderingContextStore extends AbstractContextStore
                 try {
                     return this.syntaxRegistry.resolveSyntax(value.toString());
                 } catch (ParseException e) {
-                    this.logger.warn("Failed to restore the Syntax for key [{}]", key, e);
+                    this.logger.warn("Failed to restore the Syntax for key [{}]. Cause: [{}]", key,
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/link/DefaultXHTMLLinkRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml/src/main/java/org/xwiki/rendering/internal/renderer/xhtml/link/DefaultXHTMLLinkRenderer.java
@@ -108,7 +108,8 @@ public class DefaultXHTMLLinkRenderer implements XHTMLLinkRenderer
                     this.componentManagerProvider.get().getInstance(XHTMLLinkTypeRenderer.class,
                         reference.getType().getScheme());
             } catch (ComponentLookupException e) {
-                this.logger.error("Failed to initialize XHTML link type renderer", e);
+                this.logger.error("Failed to initialize the XHTML link type renderer for resource type [{}]",
+                    reference.getType().getScheme(), e);
             }
         }
 

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-icon/src/main/java/org/xwiki/rendering/internal/transformation/icon/IconTransformation.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-icon/src/main/java/org/xwiki/rendering/internal/transformation/icon/IconTransformation.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.Initializable;
@@ -109,8 +110,8 @@ public class IconTransformation extends AbstractTransformation implements Initia
                     this.parserUtils.removeTopLevelParagraph(xdom.getChildren());
                     mergeTree(this.mappingTree, convertToDeepTree(xdom, (String) entry.getValue()));
                 } catch (ParseException e) {
-                    this.logger.warn("Failed to parse icon symbols [" + entry.getKey() + "]. Reason = ["
-                        + e.getMessage() + "]");
+                    this.logger.warn("Failed to parse icon symbols [{}]. Cause: [{}]", entry.getKey(),
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/MacroTransformation.java
@@ -539,7 +539,7 @@ public class MacroTransformation extends AbstractTransformation implements Initi
         try {
             prepare(block, syntax);
         } catch (StackOverflowError e) {
-            this.logger.error("Failed to prepare the block", e);
+            this.logger.error("Failed to prepare the block for syntax [{}]", syntax, e);
         }
     }
 
@@ -562,9 +562,9 @@ public class MacroTransformation extends AbstractTransformation implements Initi
             try {
                 macro = this.macroManager.getMacro(new MacroId(macroBlock.getId(), currentSyntax));
             } catch (Exception e) {
-                this.logger.debug(
-                    "Failed to get the macro with identifier [{}] for syntax [{}] (this macro block won't be prepared): {}",
-                    macroBlock.getId(), currentSyntax, ExceptionUtils.getRootCauseMessage(e));
+                this.logger.debug("Failed to get the macro with identifier [{}] for syntax [{}] (this macro block "
+                        + "won't be prepared). Cause: [{}]", macroBlock.getId(), currentSyntax,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
 
             // Prepare the macro block
@@ -572,7 +572,8 @@ public class MacroTransformation extends AbstractTransformation implements Initi
                 try {
                     macro.prepare(macroBlock);
                 } catch (Exception e) {
-                    this.logger.error("Failed to prepare the macro block", e);
+                    this.logger.error("Failed to prepare the macro block for macro [{}] and syntax [{}]",
+                        macroBlock.getId(), currentSyntax, e);
                 }
             }
         }


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` commit, mechanical code-quality fixes that do not warrant a JIRA issue.

# Changes

## Description

Audit of every logging call site under `src/main/java` (33 of them) against the
[Logging Best Practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices),
and fix the violations found.

* **Do not print a stack trace in a warning.** `RenderingContextStore` was passing the exception as
  the trailing SLF4J argument, which SLF4J interprets as a throwable and logs as a full stack trace.
  Stack traces are reserved for `error`; log `ExceptionUtils.getRootCauseMessage()` instead.
* **Use the parameterized SLF4J signature instead of string concatenation.** `IconTransformation`
  was building its message with `+`, and used `e.getMessage()` rather than the root cause message.
* **Surround parameters with `[]`.** The trailing placeholder of the `MacroTransformation` debug
  message was bare (`: {}`). Reformatting it also brought that line back under 120 characters (it
  was 126).
* **Log as much information as possible.** Four `error` calls logged only a bare sentence plus a
  stack trace, with no way to tell *which* macro / syntax / resource type failed:

  | Location | Parameter added |
  | --- | --- |
  | `MacroTransformation#prepare(Block)` | syntax |
  | `MacroTransformation#prepare(Block, Syntax)` | macro id + syntax |
  | `DefaultResourceReferenceParser#parse` | resource type prefix |
  | `DefaultXHTMLLinkRenderer#getXHTMLLinkTypeRenderer` | resource type scheme |

## Clarifications

* In `MacroTransformation#prepare(Block)` the syntax is logged rather than the block itself: that
  `catch` handles a `StackOverflowError`, and `AbstractBlock#toString()` recurses through all
  children, so rendering the block could overflow the stack again while building the message.
* No test or resource file asserts on any of the changed strings, so no test updates are needed.
* Verified clean, no change needed: no placeholder/argument-count mismatches at any call site; all
  components inject `Logger` and non-components use `private static final Logger LOGGER`; no
  double-bracket cases (the `Block` parameters in `PutFootnotesMacro` render as `CompositeBlock:[…]`,
  so the leading `[` is not doubled); the four
  `BlockStateChainingListener` `debug(msg, new IllegalStateException())` calls are already guarded by
  `isDebugEnabled()`.
* Left alone deliberately, out of scope for this PR:
  * `XWikiSerializer2` uses `java.util.logging.Logger` instead of SLF4J. The field is never actually
    used to log, but it is exposed through public `getLogger()`/`setLogger()`, so replacing it is a
    breaking API change needing deprecation, a legacy re-add and a Revapi ignore.
  * `"Failed to initialize the default WikiModel implementation"` (`BlockNoteRenderer`,
    `AttachmentXHTMLImageTypeRenderer`) is inaccurate — nothing is initialized, it is a
    `ComponentLookupException` from looking up whichever `WikiModel` is registered, and there is no
    "default implementation". The identical wording exists in xwiki-platform, so changing it here
    only would desynchronize the two.
  * The cause suffix is inconsistent repo-wide (`Cause: [{}]` in most places, `Cause [{}].` in
    `ListenerRegistry`, `Root reason [{}]` in `DefaultTransformationManager`). Purely cosmetic and
    not a rule breach.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn -B -ntp install \
  -pl xwiki-rendering-api,\
xwiki-rendering-transformations/xwiki-rendering-transformation-icon,\
xwiki-rendering-transformations/xwiki-rendering-transformation-macro,\
xwiki-rendering-syntaxes/xwiki-rendering-syntax-xhtml
```

All four modules `SUCCESS` — tests, Checkstyle and JaCoCo all green.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — cosmetic logging cleanup on `master` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
