### PR TITLE
[Misc] Apply the logging best practices: don't drop the caught exception in a warn()

### DIFF
--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-linkchecker/src/main/java/org/xwiki/rendering/internal/transformation/linkchecker/DefaultLinkCheckerThread.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-linkchecker/src/main/java/org/xwiki/rendering/internal/transformation/linkchecker/DefaultLinkCheckerThread.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
@@ -231,9 +232,10 @@ public class DefaultLinkCheckerThread extends java.lang.Thread implements LinkCh
             ObservationManager observationManager = this.observationManagerProvider.get();
             observationManager.notify(new InvalidURLEvent(url), data);
         } catch (Exception e) {
-            // Failed to find an Observation Manager, continnue, but log a warning since it's not really normal
+            // Failed to find an Observation Manager, continue, but log a warning since it's not really normal
             this.logger.warn("The Invalid URL Event for URL [{}] (source [{}]) wasn't sent as no Observation Manager "
-                + "Component was found", url, data.get(EVENT_DATA_SOURCE));
+                + "Component was found. Root cause is [{}]", url, data.get(EVENT_DATA_SOURCE),
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-linkchecker/src/test/java/org/xwiki/rendering/internal/transformation/linkchecker/LinkCheckerThreadTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-linkchecker/src/test/java/org/xwiki/rendering/internal/transformation/linkchecker/LinkCheckerThreadTest.java
@@ -152,6 +152,6 @@ class LinkCheckerThreadTest
         this.thread.processLinkQueue();
 
         assertEquals("The Invalid URL Event for URL [linkreference] (source [someref]) wasn't sent as no Observation "
-            + "Manager Component was found", logCapture.getMessage(0));
+            + "Manager Component was found. Root cause is [RuntimeException: error]", logCapture.getMessage(0));
     }
 }

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroManager.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/macro/DefaultMacroManager.java
@@ -28,6 +28,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -104,8 +105,9 @@ public class DefaultMacroManager implements MacroManager
                         + "The hint should contain either the macro name only or the macro name followed by "
                         + "the syntax for which it is valid. In that case the macro name should be followed by a "
                         + "\"/\" followed by the syntax name followed by another \"/\" followed by the syntax version. "
-                        + "For example \"html/xwiki/2.0\". This macro will not be available in the system.",
-                    entry.getKey());
+                        + "For example \"html/xwiki/2.0\". This macro will not be available in the system. "
+                        + "Root cause is [{}]",
+                    entry.getKey(), ExceptionUtils.getRootCauseMessage(e));
                 continue;
             }
             if (syntax == null || macroId.getSyntax() == null || syntax.equals(macroId.getSyntax())) {

--- a/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
+++ b/xwiki-rendering-transformations/xwiki-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/macro/DefaultMacroManagerTest.java
@@ -209,7 +209,8 @@ class DefaultMacroManagerTest
         assertEquals("Invalid Macro descriptor format for hint [macro/invalidsyntax]. The hint should contain either "
             + "the macro name only or the macro name followed by the syntax for which it is valid. In that case the "
             + "macro name should be followed by a \"/\" followed by the syntax name followed by another \"/\" followed "
-            + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the system.",
+            + "by the syntax version. For example \"html/xwiki/2.0\". This macro will not be available in the "
+            + "system. Root cause is [ParseException: Invalid macro id format [macro/invalidsyntax]]",
             logCapture.getMessage(0));
     }
 


### PR DESCRIPTION
The six-pass logging audit that ran over `xwiki-platform` (PRs #6055 … #6079 there) had never been pointed at this repository. This is that scan, re-implemented as a single parser covering all six passes' categories: placeholder arity and syntax, bracketing, `warn()` with a Throwable, concatenated / `String.format()` messages, `e.getMessage()`, calls with no message literal at all, `printStackTrace()`, `System.out`, redundant level guards, what a `catch` does with the exception it holds, and how the `Logger` field is acquired, named and modified. It resolves every `Logger`-typed identifier in a file rather than matching a receiver named `logger`, so a differently-named field is not invisible to it.

Over 667 `src/main/java` files it reports **8 candidates, of which 2 are real** — and `src/test/java` adds nothing at all.

### The two fixes

Both are the same defect: a `warn()` inside a `catch` that never mentions the exception, so **the reason the operation failed reached no log at all**. `warn()` must not print a stack trace, so the cause goes into a placeholder:

- **`DefaultLinkCheckerThread.sendEvent`** — `catch (Exception e)` around the Observation Manager lookup. The comment says "log a warning since it's not really normal", but nothing said *what* was not normal.
- **`DefaultMacroManager.getMacroIds`** — `catch (ParseException e)` on an invalid macro id. The message explains the *expected* format at length; the exception is the only thing that said which part of the actual hint was wrong (`Invalid macro id format [macro/invalidsyntax]`).

Both tests that pin these messages are updated. Also fixes `continnue` in the comment immediately above the link-checker change.

### The six candidates that are not violations

Recorded here so a future re-run recognises them instead of re-deciding:

- **The four `if (LOGGER.isDebugEnabled())` guards in `BlockStateChainingListener`** (invalid definition-list / list nesting). The pass-4 rule is to unwrap a guard around a single parameterized call — *unless the guard also skips real work*. Each of these calls builds a `new IllegalStateException()`, i.e. captures a stack trace, and argument evaluation is **not** deferred by SLF4J. Removing the guard would pay a stack-trace capture on every misnested list item in every parse. They are also `else if` branches of a real condition, so the guard is load-bearing in the control flow as well.
- **`JspWikiSerializer.print` / `println`'s `System.out`** — the serializer's output sink when no buffer is set, i.e. console output *is* the point (the same call as `MimeTypesUtil.main` in the platform audit). The class is also part of the integrated WikiModel code.

### Verification

`mvn -B -ntp test` green from `xwiki-rendering-transformation-macro` (93 tests) and from `xwiki-rendering-transformation-linkchecker` (13 tests).
