### PR TITLE
XRENDERING-812: PrintTextListener duplicates the no-op listener callbacks of EmptyWemListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,58 @@
                     XRENDERING-173 and never called. XWiki syntax rendering is handled by the renderers in
                     xwiki-rendering-syntaxes.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <new>class org.xwiki.rendering.wikimodel.PrintTextListener</new>
+                  <criticality>allowed</criticality>
+                  <justification>
+                    PrintTextListener extends EmptyWemListener instead of implementing IWemListener directly, so that
+                    the no-op listener callbacks it used to redeclare are inherited instead of being copied.
+                    EmptyWemListener supplies exactly the empty bodies that were declared before, and the only members
+                    it adds to these types are the no-arg beginDocument() and endDocument() no-ops. No existing method
+                    is removed or changed.
+                  </justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <new>class org.xwiki.rendering.wikimodel.EventDumpListener</new>
+                  <criticality>allowed</criticality>
+                  <justification>
+                    This class is not modified itself; it is a subclass of PrintTextListener, which now extends
+                    EmptyWemListener instead of implementing IWemListener directly, so EmptyWemListener appears in this
+                    class's inherited hierarchy too. EmptyWemListener supplies exactly the empty listener callbacks that
+                    PrintTextListener declared before, and the only members it adds to these types are the no-arg
+                    beginDocument() and endDocument() no-ops. No existing method is removed or changed.
+                  </justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <new>class org.xwiki.rendering.wikimodel.xhtml.PrintInlineListener</new>
+                  <criticality>allowed</criticality>
+                  <justification>
+                    This class is not modified itself; it is a subclass of PrintTextListener, which now extends
+                    EmptyWemListener instead of implementing IWemListener directly, so EmptyWemListener appears in this
+                    class's inherited hierarchy too. EmptyWemListener supplies exactly the empty listener callbacks that
+                    PrintTextListener declared before, and the only members it adds to these types are the no-arg
+                    beginDocument() and endDocument() no-ops. No existing method is removed or changed.
+                  </justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.nonFinalClassInheritsFromNewClass</code>
+                  <new>class org.xwiki.rendering.wikimodel.xhtml.PrintListener</new>
+                  <criticality>allowed</criticality>
+                  <justification>
+                    This class is not modified itself; it is a subclass of PrintTextListener, which now extends
+                    EmptyWemListener instead of implementing IWemListener directly, so EmptyWemListener appears in this
+                    class's inherited hierarchy too. EmptyWemListener supplies exactly the empty listener callbacks that
+                    PrintTextListener declared before, and the only members it adds to these types are the no-arg
+                    beginDocument() and endDocument() no-ops. No existing method is removed or changed.
+                  </justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/PrintTextListener.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/PrintTextListener.java
@@ -23,7 +23,7 @@ package org.xwiki.rendering.wikimodel;
  * @version $Id$
  * @since 4.0M1
  */
-public class PrintTextListener implements IWemListener
+public class PrintTextListener extends EmptyWemListener
 {
     private final IWikiPrinter fPrinter;
 
@@ -58,176 +58,6 @@ public class PrintTextListener implements IWemListener
     }
 
     /**
-     * @see IWemListener#beginDefinitionDescription()
-     */
-    public void beginDefinitionDescription()
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginDefinitionList(WikiParameters)
-     */
-    public void beginDefinitionList(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginDefinitionTerm()
-     */
-    public void beginDefinitionTerm()
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListenerDocument#beginDocument(WikiParameters)
-     */
-    public void beginDocument(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginFormat(WikiFormat)
-     */
-    public void beginFormat(WikiFormat format)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginHeader(int, WikiParameters)
-     */
-    public void beginHeader(int headerLevel, WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginInfoBlock(String,
-     *      WikiParameters)
-     */
-    public void beginInfoBlock(String infoType, WikiParameters params)
-    {
-        //
-    }
-
-    /**
-     * @see IWemListener#beginList(WikiParameters,
-     *      boolean)
-     */
-    public void beginList(WikiParameters params, boolean ordered)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginListItem()
-     */
-    public void beginListItem()
-    {
-        // Nothing to print for this event.
-    }
-
-    @Override
-    public void beginListItem(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginParagraph(WikiParameters)
-     */
-    public void beginParagraph(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginPropertyBlock(java.lang.String,
-     *      boolean)
-     */
-    public void beginPropertyBlock(String propertyUri, boolean doc)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginPropertyInline(java.lang.String)
-     */
-    public void beginPropertyInline(String str)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginQuotation(WikiParameters)
-     */
-    public void beginQuotation(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginQuotationLine()
-     */
-    public void beginQuotationLine()
-    {
-        //
-    }
-
-    /**
-     * @see IWemListenerDocument#beginSection(int, int,
-     *      WikiParameters)
-     */
-    public void beginSection(
-        int docLevel,
-        int headerLevel,
-        WikiParameters params)
-    {
-        // 
-    }
-
-    /**
-     * @see IWemListenerDocument#beginSectionContent(int, int,
-     *      WikiParameters)
-     */
-    public void beginSectionContent(
-        int docLevel,
-        int headerLevel,
-        WikiParameters params)
-    {
-        // 
-    }
-
-    /**
-     * @see IWemListener#beginTable(WikiParameters)
-     */
-    public void beginTable(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginTableCell(boolean,
-     *      WikiParameters)
-     */
-    public void beginTableCell(boolean tableHead, WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#beginTableRow(WikiParameters)
-     */
-    public void beginTableRow(WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
      * This method is called at the end of each block element. It can be
      * overloaded in subclasses.
      */
@@ -253,11 +83,13 @@ public class PrintTextListener implements IWemListener
     }
 
     /**
-     * @see IWemListener#endDefinitionTerm()
+     * @see IWemListenerDocument#beginDocument(WikiParameters)
      */
-    public void endDefinitionTerm()
+    @Override
+    public void beginDocument(WikiParameters params)
     {
-        // Nothing to print for this event.
+        // Overridden to stay a no-op. EmptyWemListener#beginDocument(WikiParameters) forwards to the no-arg
+        // beginDocument(), which would invoke a subclass override of it; nothing is printed for this event.
     }
 
     /**
@@ -266,14 +98,6 @@ public class PrintTextListener implements IWemListener
     public void endDocument(WikiParameters params)
     {
         endBlock();
-    }
-
-    /**
-     * @see IWemListener#endFormat(WikiFormat)
-     */
-    public void endFormat(WikiFormat format)
-    {
-        // Nothing to print for this event.
     }
 
     /**
@@ -334,14 +158,6 @@ public class PrintTextListener implements IWemListener
     }
 
     /**
-     * @see IWemListener#endPropertyInline(java.lang.String)
-     */
-    public void endPropertyInline(String inlineProperty)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
      * @see IWemListener#endQuotation(WikiParameters)
      */
     public void endQuotation(WikiParameters params)
@@ -350,56 +166,11 @@ public class PrintTextListener implements IWemListener
     }
 
     /**
-     * @see IWemListener#endQuotationLine()
-     */
-    public void endQuotationLine()
-    {
-        //
-    }
-
-    /**
-     * @see IWemListenerDocument#endSection(int, int,
-     *      WikiParameters)
-     */
-    public void endSection(int docLevel, int headerLevel, WikiParameters params)
-    {
-        // 
-    }
-
-    /**
-     * @see IWemListenerDocument#endSectionContent(int, int,
-     *      WikiParameters)
-     */
-    public void endSectionContent(
-        int docLevel,
-        int headerLevel,
-        WikiParameters params)
-    {
-        //
-    }
-
-    /**
      * @see IWemListener#endTable(WikiParameters)
      */
     public void endTable(WikiParameters params)
     {
         endBlock();
-    }
-
-    /**
-     * @see IWemListener#endTableCell(boolean, WikiParameters)
-     */
-    public void endTableCell(boolean tableHead, WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#endTableRow(WikiParameters)
-     */
-    public void endTableRow(WikiParameters params)
-    {
-        // Nothing to print for this event.
     }
 
     protected ReferenceHandler newReferenceHandler()
@@ -427,36 +198,12 @@ public class PrintTextListener implements IWemListener
         };
     }
 
-    public void onEmptyLines(int count)
-    {
-        //
-    }
-
     /**
      * @see IWemListener#onEscape(java.lang.String)
      */
     public void onEscape(String str)
     {
         print(str);
-    }
-
-    public void onExtensionBlock(String extensionName, WikiParameters params)
-    {
-        //
-    }
-
-    public void onExtensionInline(String extensionName, WikiParameters params)
-    {
-        // Nothing to print for this event.
-    }
-
-    /**
-     * @see IWemListener#onHorizontalLine(WikiParameters
-     *      params)
-     */
-    public void onHorizontalLine(WikiParameters params)
-    {
-        // Nothing to print for this event.
     }
 
     public void onImage(String ref)
@@ -486,22 +233,6 @@ public class PrintTextListener implements IWemListener
     public void onLineBreak()
     {
         println("");
-    }
-
-    public void onMacroBlock(
-        String macroName,
-        WikiParameters params,
-        String content)
-    {
-        // Nothing to print for this event.
-    }
-
-    public void onMacroInline(
-        String macroName,
-        WikiParameters params,
-        String content)
-    {
-        // Nothing to print for this event.
     }
 
     /**
@@ -540,14 +271,6 @@ public class PrintTextListener implements IWemListener
     public void onSpecialSymbol(String str)
     {
         print(str);
-    }
-
-    /**
-     * @see IWemListener#onTableCaption(java.lang.String)
-     */
-    public void onTableCaption(String str)
-    {
-        // Nothing to print for this event.
     }
 
     /**


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XRENDERING-812

# Changes

## Description

* `PrintTextListener` implemented `IWemListener` directly and redeclared 35 of its callbacks with empty bodies, even though `EmptyWemListener` — sitting in the same package — already provides exactly those empty implementations. Both classes therefore carried the same run of identically-signed empty methods, in the same order, which SonarCloud's copy-paste detector reports as a 134-line duplicated block (`PrintTextListener` 95-228 vs `EmptyWemListener` 76-197).
* `PrintTextListener` now extends `EmptyWemListener` and the 34 redundant no-op callbacks are gone. The file goes from 594 to 317 lines. Two empty methods remain (`endBlock()` and `beginDocument(WikiParameters)`), both isolated, so no duplicated block can form.
* Adds four justified Revapi ignores for the `java.class.nonFinalClassInheritsFromNewClass` difference the new supertype introduces.

This clears the failing SonarCloud quality gate on `org.xwiki.rendering:xwiki-rendering`: `new_duplicated_lines_density` was 4.5% against a 3% threshold, and this file was the only contributor (12 duplicated lines out of 265 new lines project-wide). Every other gate condition already passed.

## Clarifications

* **No behaviour change and no user-visible change.**
* **`beginDocument(WikiParameters)` is deliberately kept as an explicit no-op override** rather than being inherited. `EmptyWemListener` forwards it to the no-arg `beginDocument()`, so inheriting it would start invoking a subclass override of `beginDocument()` that was never called before. This was caught by an old-against-new runtime test, not by static analysis — see below. `endDocument(WikiParameters)` was never at risk: it has a real body and stays declared.
* **The duplication is long-standing, not new.** It only started counting against the gate once 646503351 (a comment-only S1186 fix) re-dated 12 lines inside the existing duplicated block into the 30-day new-code period.
* **Backward compatibility was verified explicitly**, since this stops declaring 34 public methods on a public class:
  * The methods stay reachable through the new superclass, so JVM resolution (JVMS 5.4.3.3) still finds them. **japicmp** reports every removal as `binaryCompatible=true` and passes with `breakBuildOnBinaryIncompatibleModifications=true`.
  * The public method set changes by exactly `+beginDocument()` and `+endDocument()` — purely additive, zero removals.
  * `xwiki-platform` has **no** reference to `PrintTextListener`, `EmptyWemListener`, `PrintInlineListener`, `EventDumpListener` or `PrintListener` — no usages, no subclasses.
  * One difference remains and is inherent to moving methods to a superclass: `getDeclaredMethods()` on `PrintTextListener` drops from 66 to 32, so `getDeclaredMethod(...)` for a moved method now throws. `getMethod()`/`getMethods()` are unaffected, and nothing in rendering or platform does declared-method reflection on these types.

# Screenshots & Video

Not applicable — no UI change.

# Executed Tests

* Single module, all checks including Checkstyle, Revapi and the JaCoCo ratio:
  `mvn clean install -B -ntp -pl xwiki-rendering-wikimodel -Plegacy,quality` → **BUILD SUCCESS**, 138 tests pass.
* Whole repository: `mvn clean install -B -ntp -Plegacy,quality -fae` → **BUILD SUCCESS**, all 44 modules.
* Binary-compatibility check: `japicmp` 0.16.0 comparing the pre-change jar against the post-change jar with `breakBuildOnBinaryIncompatibleModifications=true` → no incompatibility.
* Runtime load test: a consumer compiled against the **pre-change** jar and run against the **post-change** jar, covering `invokevirtual` on all removed methods, `invokeinterface` via `IWemListener`, a subclass overriding removed methods and calling `super.xxx()` (`invokespecial`), a subclass overriding nothing, a subclass declaring its own no-arg `beginDocument()`/`endDocument()`, `instanceof`, and reflection. All call paths behave identically to the pre-change jar; the only reported difference is the `getDeclaredMethod` one noted above.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — this is a code-quality change on `master` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
