### PR TITLE
[Misc] Analyze pull requests with SonarCloud and fail on their quality gate

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,0 +1,105 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Analyze each pull request with SonarCloud and fail when the pull request's quality gate fails, so
+## that a change introducing SonarQube issues is caught before it is merged instead of turning the
+## master quality gate red afterwards. This is not a duplicate of the ci.xwiki.org "quality" build:
+## that one analyzes master after the merge, with the tests and the coverage, whereas this one only
+## needs the bytecode of the changed code.
+name: SonarCloud PR analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+## One analysis per pull request: a new commit makes the running one obsolete.
+concurrency:
+  group: sonar-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Analyze
+    ## A pull_request run from a fork gets no repository secrets, so the analysis has no token to
+    ## authenticate with. Skip those rather than fail them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## SonarCloud derives the lines the pull request changed from the git history.
+          fetch-depth: 0
+
+      ## The JDK to build with is the one the branch targets, which is the xwiki.java.version property
+      ## of the effective root pom. It is read with Maven rather than searched for in the pom text
+      ## because the property is not necessarily declared in the repository being built: xwiki-rendering
+      ## and xwiki-platform inherit it from the xwiki-commons parent, which Maven has to download to
+      ## know it. -N keeps the evaluation to the root pom, and -Psnapshot supplies the XWiki
+      ## repositories that parent is downloaded from, since a runner has no settings.xml declaring
+      ## them. The JDK preinstalled on the runner is enough to run this: the goal builds the pom model,
+      ## it compiles nothing.
+      - name: Read the Java version of the branch
+        id: java
+        run: |
+          VERSION=$(mvn -N -B -ntp -q -DforceStdout -Psnapshot help:evaluate \
+            -Dexpression=xwiki.java.version)
+          ## An undefined property makes help:evaluate print a message and still succeed, which would
+          ## otherwise surface as an obscure setup-java failure.
+          if [[ ! "$VERSION" =~ ^[0-9]+$ ]]; then
+            echo "::error::Failed to read xwiki.java.version from the root pom, got [$VERSION]"
+            exit 1
+          fi
+          echo "Building with Java $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ steps.java.outputs.version }}
+          cache: maven
+
+      ## Compile only. The analysis needs the bytecode, not the test results, and no coverage as long
+      ## as the quality gate keeps its condition on the coverage of new code disabled. The snapshot
+      ## profile is what supplies the XWiki repositories the parent pom and the xwiki-commons
+      ## snapshots are downloaded from, a runner having no settings.xml declaring them.
+      - name: Build
+        run: >
+          mvn -B -ntp -T 1C install -DskipTests -Psnapshot
+          -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true
+          -Dxwiki.enforcer.skip=true -Dxwiki.spoon.skip=true
+
+      ## sonar.qualitygate.wait makes the goal wait for the server to process the report and fail the
+      ## job when the quality gate fails. Without it the job would pass whatever the analysis found.
+      ## The pull request properties go through the environment rather than being interpolated into the
+      ## command: a branch name is chosen by whoever opens the pull request, and ${{ }} is substituted
+      ## into the script before the shell runs it, so interpolating one lets a crafted branch name run
+      ## commands on the runner, where the token is.
+      - name: Analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_KEY: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+        run: >
+          mvn -B -ntp sonar:sonar -Psnapshot -Dsonar.qualitygate.wait=true
+          -Dsonar.pullrequest.key="$PR_KEY"
+          -Dsonar.pullrequest.branch="$PR_BRANCH"
+          -Dsonar.pullrequest.base="$PR_BASE"


### PR DESCRIPTION
# Jira URL

N/A ([Misc] commit)

# Changes

## Description

* Add the `SonarCloud PR analysis` GitHub Actions workflow that xwiki-commons already has: it compiles the reactor
  without the tests and runs a SonarCloud pull request analysis with `sonar.qualitygate.wait=true`, so the job fails
  when the pull request's own quality gate fails.

## Clarifications

* **Why.** A change that adds SonarQube issues is currently only discovered by the post-merge `master` analysis, i.e.
  once the `master` quality gate is already red. This catches it on the pull request instead. It is not a duplicate of
  the ci.xwiki.org `quality` build: that one analyzes `master` after the merge, with the tests and the coverage, while
  this one only needs the bytecode of the changed code.
* **The only difference with the xwiki-commons file is `-Psnapshot`**, on the build and on the analysis. The
  xwiki-commons root pom has no parent, so a runner can build it with no repository configured at all. This repository's
  root pom inherits from `xwiki-commons-pom` and depends on `org.xwiki.commons` snapshots, and a GitHub runner has no
  `settings.xml` declaring where those come from. The `snapshot` profile of the pom is what declares them.
* **The JDK is read from the pom, not hardcoded.** The `Read the Java version of the branch` step evaluates
  `xwiki.java.version` on the effective root pom and feeds it to `actions/setup-java`, so the workflow follows the Java
  version a branch targets. That property is not declared in this repository — it is inherited from the xwiki-commons
  parent — which is why it is evaluated with Maven rather than searched for in the pom text.
* **`sonar.qualitygate.wait=true` is what turns the analysis into a gate.** Without it `sonar:sonar` exits 0 whatever
  the analysis found, and the check would be decorative.
* **Why no tests, no `-Pquality` and no coverage.** The analysis needs compiled classes, nothing else. Coverage would
  only matter if the quality gate's condition on the coverage of new code were enabled; it is currently `< 0`, i.e.
  disabled, and a no-tests analysis reports `new_coverage = 0.0` as OK.
* **Pull requests from forks are skipped**, because a `pull_request` run from a fork gets no repository secrets. The
  alternative, `pull_request_target`, would expose the token to fork code and is deliberately not used. Committer and
  bot pull requests use in-repo branches and are covered.
* The `SONAR_TOKEN` organization secret is already shared with this repository, so there is nothing to add.

# Screenshots & Video

N/A, no UI change.

# Executed Tests

* This pull request runs the new workflow on itself, since `pull_request` workflows execute the version of the file
  present on the head branch. Its result is the test.
* The build command was verified locally on Java 21, from a clean tree:
  `mvn clean install -B -ntp -T 1C -DskipTests -Psnapshot -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true
  -Dxwiki.enforcer.skip=true -Dxwiki.spoon.skip=true` → BUILD SUCCESS over the 40 modules of the reactor in 40 s.
* The `Read the Java version of the branch` step was verified in the conditions of a runner — the exact script
  extracted from the workflow, run under `bash -e` on JDK 17 (the JDK a GitHub runner defaults to), with an empty local
  Maven repository and an empty `settings.xml`. It resolves the xwiki-commons parent over the network and outputs
  `version=21`. Without `-Psnapshot` the same run fails with `UnresolvableModelException`, which is what that flag is
  there for. Both failure paths were checked too: an undefined property and a Maven failure each exit 1 with a
  `::error::` annotation instead of silently producing an empty version.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

