### PR TITLE
XRENDERING-814: Support supplementary characters when validating XML names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,30 @@
                 </item>
                 <item>
                   <ignore>true</ignore>
+                  <code>java.method.parameterTypeChanged</code>
+                  <old>parameter boolean org.xwiki.rendering.wikimodel.WikiPageUtil::isValidXmlNameChar(===char===, boolean)</old>
+                  <new>parameter boolean org.xwiki.rendering.wikimodel.WikiPageUtil::isValidXmlNameChar(===int===, boolean)</new>
+                  <parameterIndex>0</parameterIndex>
+                  <criticality>allowed</criticality>
+                  <justification>Replaced by isValidXmlNameChar(int, boolean), which takes a code point and can
+                    therefore express the whole XML NameChar production, including the supplementary range
+                    #x10000-#xEFFFF that a char cannot hold. The char signature is re-added by the
+                    xwiki-rendering-legacy-wikimodel module.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.parameterTypeChanged</code>
+                  <old>parameter boolean org.xwiki.rendering.wikimodel.WikiPageUtil::isValidXmlNameStartChar(===char===, boolean)</old>
+                  <new>parameter boolean org.xwiki.rendering.wikimodel.WikiPageUtil::isValidXmlNameStartChar(===int===, boolean)</new>
+                  <parameterIndex>0</parameterIndex>
+                  <criticality>allowed</criticality>
+                  <justification>Replaced by isValidXmlNameStartChar(int, boolean), which takes a code point and can
+                    therefore express the whole XML NameStartChar production, including the supplementary range
+                    #x10000-#xEFFFF that a char cannot hold. The char signature is re-added by the
+                    xwiki-rendering-legacy-wikimodel module.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
                   <code>java.class.nonFinalClassInheritsFromNewClass</code>
                   <new>class org.xwiki.rendering.wikimodel.PrintTextListener</new>
                   <criticality>allowed</criticality>

--- a/xwiki-rendering-legacy/pom.xml
+++ b/xwiki-rendering-legacy/pom.xml
@@ -38,6 +38,7 @@
   <modules>
     <module>xwiki-rendering-legacy-api</module>
     <module>xwiki-rendering-legacy-transformations</module>
+    <module>xwiki-rendering-legacy-wikimodel</module>
   </modules>
   <dependencies>
     <!-- Needed for backward compatibility Aspects -->

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/pom.xml
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.rendering</groupId>
+    <artifactId>xwiki-rendering-legacy</artifactId>
+    <version>18.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-rendering-legacy-wikimodel</artifactId>
+  <name>XWiki Rendering - Legacy - WikiModel</name>
+  <packaging>jar</packaging>
+  <description>Legacy module for xwiki-rendering-wikimodel</description>
+  <properties>
+    <!-- This module's jar is the whole woven xwiki-rendering-wikimodel artifact, whose tests run in that module and
+         not here, so the achieved ratio is that of the two compatibility methods against the 161 woven classes. -->
+    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+    <!-- The features provided by this module so that it's found when resolving extension. -->
+    <xwiki.extension.features>org.xwiki.rendering:xwiki-rendering-wikimodel</xwiki.extension.features>
+    <!-- The woven classes come from xwiki-rendering-wikimodel, which doesn't follow the XWiki coding style. -->
+    <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+  </properties>
+  <dependencies>
+    <!-- Trigger xwiki-rendering-wikimodel dependencies (but without xwiki-rendering-wikimodel jar itself). -->
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-wikimodel</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+    <!-- We need this dependency so that the wrapped module is built before this one. -->
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-wikimodel</artifactId>
+      <version>${project.version}</version>
+      <!-- We don't want to draw this dependency since we're wrapping it. -->
+      <scope>provided</scope>
+    </dependency>
+    <!-- Testing Dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <!-- Apply Compatibility Aspects. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>backward-compatibility-aspects</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <weaveDependencies>
+            <weaveDependency>
+              <groupId>org.xwiki.rendering</groupId>
+              <artifactId>xwiki-rendering-wikimodel</artifactId>
+            </weaveDependency>
+          </weaveDependencies>
+        </configuration>
+      </plugin>
+      <!-- Exclude AspectJ's builddef.lst file form the generated JAR since it's not useful there. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/builddef.lst</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.xwiki.rendering:xwiki-rendering-wikimodel:jar</classpathDependencyExcludes>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+      <!-- Add specific excludes for this module for license checks. -->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <!-- Exclude *.dtd files since they're not under XWiki's license headers. Those files come from the
+                     woven xwiki-rendering-wikimodel artifact. -->
+                <exclude>**/*.dtd</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/src/main/aspect/org/xwiki/rendering/wikimodel/WikiPageUtilCompatibilityAspect.aj
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/src/main/aspect/org/xwiki/rendering/wikimodel/WikiPageUtilCompatibilityAspect.aj
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.wikimodel;
+
+/**
+ * Add a backward compatibility layer to the {@link WikiPageUtil} class.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+public privileged aspect WikiPageUtilCompatibilityAspect
+{
+    /**
+     * @param ch the character to check
+     * @param colonEnabled if this flag is <code>true</code> then this method accepts the ':' symbol.
+     * @return <code>true</code> if the given value is a valid XML name character
+     * @deprecated use {@link WikiPageUtil#isValidXmlNameChar(int, boolean)} instead
+     */
+    @Deprecated(since = "18.8.0RC1")
+    public static boolean WikiPageUtil.isValidXmlNameChar(char ch, boolean colonEnabled)
+    {
+        return WikiPageUtil.isValidXmlNameChar((int) ch, colonEnabled);
+    }
+
+    /**
+     * @param ch the character to check
+     * @param colonEnabled if this flag is <code>true</code> then this method accepts the ':' symbol.
+     * @return <code>true</code> if the given value is a valid first character for an XML name
+     * @deprecated use {@link WikiPageUtil#isValidXmlNameStartChar(int, boolean)} instead
+     */
+    @Deprecated(since = "18.8.0RC1")
+    public static boolean WikiPageUtil.isValidXmlNameStartChar(char ch, boolean colonEnabled)
+    {
+        return WikiPageUtil.isValidXmlNameStartChar((int) ch, colonEnabled);
+    }
+}

--- a/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/src/test/java/org/xwiki/rendering/wikimodel/DeprecatedWikiPageUtilTest.java
+++ b/xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/src/test/java/org/xwiki/rendering/wikimodel/DeprecatedWikiPageUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.wikimodel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validate the retro compatibility of the char based methods of {@link WikiPageUtil}.
+ *
+ * @version $Id$
+ */
+class DeprecatedWikiPageUtilTest
+{
+    @Test
+    void isValidXmlNameStartChar()
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameStartChar('a', false));
+        assertTrue(WikiPageUtil.isValidXmlNameStartChar('_', false));
+        assertFalse(WikiPageUtil.isValidXmlNameStartChar('1', false));
+        assertTrue(WikiPageUtil.isValidXmlNameStartChar(':', true));
+        assertFalse(WikiPageUtil.isValidXmlNameStartChar(':', false));
+    }
+
+    @Test
+    void isValidXmlNameChar()
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameChar('a', false));
+        assertTrue(WikiPageUtil.isValidXmlNameChar('1', false));
+        assertTrue(WikiPageUtil.isValidXmlNameChar('-', false));
+        assertFalse(WikiPageUtil.isValidXmlNameChar(' ', false));
+        assertTrue(WikiPageUtil.isValidXmlNameChar(':', true));
+        assertFalse(WikiPageUtil.isValidXmlNameChar(':', false));
+    }
+
+    /**
+     * A surrogate is only half of a supplementary character, so on its own it is not a valid name character. This is
+     * why the char based signatures were replaced by code point based ones.
+     */
+    @Test
+    void isValidXmlNameCharWithSurrogate()
+    {
+        assertFalse(WikiPageUtil.isValidXmlNameChar('\uD840', false));
+        assertFalse(WikiPageUtil.isValidXmlNameChar('\uDC00', false));
+    }
+}

--- a/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/WikiPageUtil.java
+++ b/xwiki-rendering-wikimodel/src/main/java/org/xwiki/rendering/wikimodel/WikiPageUtil.java
@@ -21,6 +21,8 @@ package org.xwiki.rendering.wikimodel;
 
 import java.util.Arrays;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * This class contains some utility methods used for escaping xml strings as
  * well as for encoding/decoding http parameters.
@@ -30,6 +32,37 @@ import java.util.Arrays;
  */
 public class WikiPageUtil
 {
+    /**
+     * The code point ranges of the XML NameStartChar production, as inclusive bounds. ':' is left out since it is
+     * only accepted when the caller enables it.
+     */
+    private static final int[][] NAME_START_CHAR_RANGES = {
+        {'A', 'Z'},
+        {'_', '_'},
+        {'a', 'z'},
+        {0xC0, 0xD6},
+        {0xD8, 0xF6},
+        {0xF8, 0x2FF},
+        {0x370, 0x37D},
+        {0x37F, 0x1FFF},
+        {0x200C, 0x200D},
+        {0x2070, 0x218F},
+        {0x2C00, 0x2FEF},
+        {0x3001, 0xD7FF},
+        {0xF900, 0xFDCF},
+        {0xFDF0, 0xFFFD},
+        {0x10000, 0xEFFFF}};
+
+    /**
+     * The code point ranges the XML NameChar production adds to NameStartChar, as inclusive bounds.
+     */
+    private static final int[][] NAME_CHAR_RANGES = {
+        {'-', '.'},
+        {'0', '9'},
+        {0xB7, 0xB7},
+        {0x0300, 0x036F},
+        {0x203F, 0x2040}};
+
     /**
      * Reserved symbols - see RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)
      */
@@ -237,16 +270,20 @@ public class WikiPageUtil
     {
         boolean valid = false;
         int len = tagName != null ? tagName.length() : 0;
-        for (int i = 0; i < len; i++) {
-            char ch = tagName.charAt(i);
+        // A supplementary character is made of two chars, so walk the name by code point rather than by char,
+        // otherwise each half of a surrogate pair would be checked on its own and rejected.
+        int i = 0;
+        while (i < len) {
+            int codePoint = tagName.codePointAt(i);
             if (i == 0) {
-                valid = isValidXmlNameStartChar(ch, colonEnabled);
+                valid = isValidXmlNameStartChar(codePoint, colonEnabled);
             } else {
-                valid = isValidXmlNameChar(ch, colonEnabled);
+                valid = isValidXmlNameChar(codePoint, colonEnabled);
             }
             if (!valid) {
                 break;
             }
+            i += Character.charCount(codePoint);
         }
         return valid;
     }
@@ -257,22 +294,18 @@ public class WikiPageUtil
      * <p>
      * See http://www.w3.org/TR/xml/#NT-NameChar.
      * </p>
-     * 
-     * @param ch the character to check
+     *
+     * @param codePoint the code point to check
      * @param colonEnabled if this flag is <code>true</code> then this method
      * accepts the ':' symbol.
      * @return <code>true</code> if the given value is a valid XML name
      *         character
+     * @since 18.8.0RC1
      */
-    public static boolean isValidXmlNameChar(char ch, boolean colonEnabled)
+    @Unstable
+    public static boolean isValidXmlNameChar(int codePoint, boolean colonEnabled)
     {
-        return isValidXmlNameStartChar(ch, colonEnabled)
-            || (ch == '-')
-            || (ch == '.')
-            || (ch >= '0' && ch <= '9')
-            || (ch == 0xB7)
-            || (ch >= 0x0300 && ch <= 0x036F)
-            || (ch >= 0x203F && ch <= 0x2040);
+        return isValidXmlNameStartChar(codePoint, colonEnabled) || isInRanges(codePoint, NAME_CHAR_RANGES);
     }
 
     /**
@@ -281,32 +314,30 @@ public class WikiPageUtil
      * <p>
      * See http://www.w3.org/TR/xml/#NT-NameStartChar.
      * </p>
-     * 
-     * @param ch the character to check
+     *
+     * @param codePoint the code point to check
      * @param colonEnabled if this flag is <code>true</code> then this method
      * accepts the ':' symbol.
      * @return <code>true</code> if the given value is a valid first character
      *         for an XML name
+     * @since 18.8.0RC1
      */
-    public static boolean isValidXmlNameStartChar(char ch, boolean colonEnabled)
+    @Unstable
+    public static boolean isValidXmlNameStartChar(int codePoint, boolean colonEnabled)
     {
-        if (ch == ':') {
+        if (codePoint == ':') {
             return colonEnabled;
         }
-        return (ch >= 'A' && ch <= 'Z')
-            || ch == '_'
-            || (ch >= 'a' && ch <= 'z')
-            || (ch >= 0xC0 && ch <= 0xD6)
-            || (ch >= 0xD8 && ch <= 0xF6)
-            || (ch >= 0xF8 && ch <= 0x2FF)
-            || (ch >= 0x370 && ch <= 0x37D)
-            || (ch >= 0x37F && ch <= 0x1FFF)
-            || (ch >= 0x200C && ch <= 0x200D)
-            || (ch >= 0x2070 && ch <= 0x218F)
-            || (ch >= 0x2C00 && ch <= 0x2FEF)
-            || (ch >= 0x3001 && ch <= 0xD7FF)
-            || (ch >= 0xF900 && ch <= 0xFDCF)
-            || (ch >= 0xFDF0 && ch <= 0xFFFD)
-            || (ch >= 0x10000 && ch <= 0xEFFFF);
+        return isInRanges(codePoint, NAME_START_CHAR_RANGES);
+    }
+
+    private static boolean isInRanges(int codePoint, int[][] ranges)
+    {
+        for (int[] range : ranges) {
+            if (codePoint >= range[0] && codePoint <= range[1]) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/xwiki-rendering-wikimodel/src/test/java/org/xwiki/rendering/wikimodel/WikiPageUtilTest.java
+++ b/xwiki-rendering-wikimodel/src/test/java/org/xwiki/rendering/wikimodel/WikiPageUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.wikimodel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validate {@link WikiPageUtil}.
+ *
+ * @version $Id$
+ */
+class WikiPageUtilTest
+{
+    /**
+     * U+20000, the first code point of CJK Unified Ideographs Extension B. It is written with a surrogate pair, so
+     * it's the simplest way to check that a supplementary character isn't validated one half at a time.
+     */
+    private static final String CJK_EXTENSION_B_FIRST = new String(Character.toChars(0x20000));
+
+    @ParameterizedTest
+    @ValueSource(ints = {'A', 'Z', '_', 'a', 'z', 0xC0, 0xF8, 0x370, 0x200C, 0x2C00, 0x3001, 0xF900, 0xFDF0, 0xFFFD,
+        0x10000, 0x20000, 0xEFFFF})
+    void isValidXmlNameStartCharWithValidCodePoint(int codePoint)
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameStartChar(codePoint, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {'-', '.', '0', '9', 0xB7, 0xD7, 0xD800, 0xDC00, 0xF0000, 0x10FFFF})
+    void isValidXmlNameStartCharWithInvalidCodePoint(int codePoint)
+    {
+        assertFalse(WikiPageUtil.isValidXmlNameStartChar(codePoint, false));
+    }
+
+    @Test
+    void isValidXmlNameStartCharWithColon()
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameStartChar(':', true));
+        assertFalse(WikiPageUtil.isValidXmlNameStartChar(':', false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {'A', '_', 'a', '-', '.', '0', '9', 0xB7, 0x0300, 0x203F, 0x10000, 0x20000, 0xEFFFF})
+    void isValidXmlNameCharWithValidCodePoint(int codePoint)
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameChar(codePoint, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {' ', '/', 0xD7, 0xD800, 0xDC00, 0xF0000, 0x10FFFF})
+    void isValidXmlNameCharWithInvalidCodePoint(int codePoint)
+    {
+        assertFalse(WikiPageUtil.isValidXmlNameChar(codePoint, false));
+    }
+
+    @Test
+    void isValidXmlNameCharWithColon()
+    {
+        assertTrue(WikiPageUtil.isValidXmlNameChar(':', true));
+        assertFalse(WikiPageUtil.isValidXmlNameChar(':', false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo, false, true",
+        "_foo-1.2, false, true",
+        "1foo, false, false",
+        "-foo, false, false",
+        "foo bar, false, false",
+        "'', false, false",
+        "ns:foo, true, true",
+        "ns:foo, false, false",
+        ":foo, true, true"
+    })
+    void isValidXmlName(String tagName, boolean colonEnabled, boolean expected)
+    {
+        assertEquals(expected, WikiPageUtil.isValidXmlName(tagName, colonEnabled));
+    }
+
+    @Test
+    void isValidXmlNameWithNullName()
+    {
+        assertFalse(WikiPageUtil.isValidXmlName(null, true));
+    }
+
+    @Test
+    void isValidXmlNameWithSupplementaryCharacter()
+    {
+        assertTrue(WikiPageUtil.isValidXmlName(CJK_EXTENSION_B_FIRST, false));
+        assertTrue(WikiPageUtil.isValidXmlName(CJK_EXTENSION_B_FIRST + "foo", false));
+        assertTrue(WikiPageUtil.isValidXmlName("foo" + CJK_EXTENSION_B_FIRST, false));
+    }
+
+    @Test
+    void isValidXmlNameWithLoneSurrogate()
+    {
+        assertFalse(WikiPageUtil.isValidXmlName("\uD840", false));
+        assertFalse(WikiPageUtil.isValidXmlName("foo\uDC00", false));
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XRENDERING-814

# Changes

## Description

This supersedes #425, which fixed the two `java:S2198` issues on
`WikiPageUtil#isValidXmlNameStartChar(char, boolean)` by deleting the dead clause. That fix was
behaviour-preserving but it also gave up on the range the clause was there for. This PR instead
introduces the API that can express it, and retires the one that cannot.

`isValidXmlNameChar` and `isValidXmlNameStartChar` took a `char`, i.e. a UTF-16 code unit limited to
`0x0000`-`0xFFFF`. The XML `NameStartChar` production also allows the supplementary range
`#x10000-#xEFFFF`, which is why the methods ended with `|| (ch >= 0x10000 && ch <= 0xEFFFF)` — an
alternative that can never hold for a `char`, hence the two Sonar issues ("will always return
`false`" and "will always return `true`").

The dead clause was only the visible half of the problem. A supplementary character reaches these
methods as a surrogate pair, and each surrogate on its own (`0xD800`-`0xDFFF`) is rejected by every
alternative, so `isValidXmlName` reported a perfectly valid XML name such as U+20000 followed by
`foo` as invalid.

So:

* `isValidXmlNameChar(int codePoint, boolean)` and `isValidXmlNameStartChar(int codePoint, boolean)`
  are added; taking a code point, they express the whole production, supplementary range included.
* `isValidXmlName(String, boolean)` now walks the name by code point instead of by `char`, so a
  supplementary character is validated as the single character it is.
* The `char` overloads are deprecated and **moved out of `xwiki-rendering-wikimodel`** into the new
  `xwiki-rendering-legacy-wikimodel` module, which weaves the main artifact with AspectJ and re-adds
  them as `@Deprecated` inter-type declarations delegating to the code point versions. The main jar
  therefore exposes only the code point API, while extensions compiled against the `char` signatures
  keep working:

  ```
  $ javap -cp xwiki-rendering-wikimodel/target/classes org.xwiki.rendering.wikimodel.WikiPageUtil
    public static boolean isValidXmlName(java.lang.String, boolean);
    public static boolean isValidXmlNameChar(int, boolean);
    public static boolean isValidXmlNameStartChar(int, boolean);

  $ javap -cp xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel/target/classes org.xwiki.rendering.wikimodel.WikiPageUtil
    public static boolean isValidXmlName(java.lang.String, boolean);
    public static boolean isValidXmlNameChar(int, boolean);
    public static boolean isValidXmlNameStartChar(int, boolean);
    public static boolean isValidXmlNameChar(char, boolean);
    public static boolean isValidXmlNameStartChar(char, boolean);
  ```

## Clarifications

* The two productions are now transcribed as `NAME_START_CHAR_RANGES` / `NAME_CHAR_RANGES` tables of
  inclusive bounds scanned by a small `isInRanges` helper, instead of a chain of `||`. Same result for
  every code point, and it keeps `isValidXmlNameStartChar` under SonarCloud's cognitive-complexity
  limit — the chain scored 28 against a limit of 15, and rewriting the method's lines made the PR own
  that pre-existing issue.
* **Source compatibility is untouched.** A call site passing a `char` widens to `int` and binds to
  the new overload, which returns exactly what the old one did for every one of the 65536 `char`
  values (the removed clause never fired). There were no in-repo callers of the `char` methods, and
  none in xwiki-platform either.
* **Revapi.** The removal is reported as `java.method.parameterTypeChanged` (`char` → `int`), not as
  a removal plus an addition; the two ignores in the root `pom.xml` are worded accordingly and set to
  `allowed` since the signature is re-added by the legacy module. Verified by running
  `revapi:check` with and without them — it fails without, passes with.
* **`xwiki-rendering-legacy-wikimodel` is a new weaving module**, so it is a full replacement of
  `xwiki-rendering-wikimodel` and the two must not both land in the WAR. The companion PR
  https://github.com/xwiki/xwiki-platform/pull/6285 bans the clean jar and packages the legacy
  one instead. **These two PRs must be merged together.**
* Its `xwiki.jacoco.instructionRatio` is `0.00`: the jar is the whole woven wikimodel artifact (161
  classes) whose tests run in its own module, against two delegating compatibility methods here.
  Checkstyle is skipped for the same reason `xwiki-rendering-wikimodel` skips it — the woven code is
  not on the XWiki coding style.
* `WikiPageUtil` had no test at all; this adds `WikiPageUtilTest` (main module, code point API and
  the supplementary/lone-surrogate cases) and `DeprecatedWikiPageUtilTest` (legacy module, the woven
  `char` signatures).

# Screenshots & Video

N/A — no visible result, this is an API change.

# Executed Tests

```
mvn clean install -B -ntp -pl xwiki-rendering-wikimodel -Plegacy,quality
mvn clean install -B -ntp -Plegacy,quality \
  -pl xwiki-rendering-legacy,xwiki-rendering-legacy/xwiki-rendering-legacy-wikimodel
mvn clean install -B -ntp -Plegacy \
  -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true
```

All `BUILD SUCCESS`. The first two run Revapi and the JaCoCo coverage check; the third is the full
reactor including the legacy modules.

# Expected merging strategy

Prefers squash: Yes. No backport — new API on the current dev version.

# Related

* Supersedes #425.
* Companion, must merge together: https://github.com/xwiki/xwiki-platform/pull/6285

---
_Generated with [Claude Code](https://claude.com/claude-code)_
