### PR TITLE
XRENDERING-815: XWiki syntax renderer doesn't escape closing macro syntax in various attributes

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro38.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro38.test
@@ -1,0 +1,21 @@
+.runTransformations
+.#-----------------------------------------------------
+.# A group parameter value inside a box macro contains the macro's own closing marker ({{/box}}). When the box is
+.# edited in the WYSIWYG editor, that value lives as a real HTML attribute inside the data-xwiki-non-generated-content
+.# wrapper, so on save the xhtml/1.0 parser takes the content from there (not from the opaque macro comment) and
+.# re-renders it to XWiki syntax. The renderer must re-escape the "{{" so that the box is not closed early on the next
+.# parse.
+.#
+.# The escaping is done by XWikiSyntaxChainingRenderer#printParameters, which applies
+.# XWikiSyntaxEscapeHandler#escapeCurlyBrackets to the parameter value the way text is already escaped. Without it the
+.# parameter would be emitted as (% class="{{/box}}" %), which re-parses as a premature {{/box}}.
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:box|-||-|(% class="~\{~\{/box}}" %)Info content--><div class="box"><div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p><span class="&#123;&#123;/box}}">Info content</span></p></div></div><!--stopmacro-->
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+(% class="~{~{/box}}" %)Info content
+{{/box}}

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro39.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro39.test
@@ -1,0 +1,19 @@
+.runTransformations
+.#-----------------------------------------------------
+.# Same problem as macro38 but for a link reference: a link inside a box macro points at a reference that contains the
+.# macro's own closing marker ({{/box}}). It survives WYSIWYG editing inside the data-xwiki-non-generated-content
+.# wrapper (the reference is carried by the startwikilink annotation) and is re-rendered to XWiki syntax on save. The
+.# resource reference serializer must re-escape the "{{".
+.#
+.# The escaping is done by XWikiSyntaxResourceRenderer#serialize, which escapes "{{" like it already escapes "]]".
+.# Without it the reference would be emitted as [[label>>{{/box}}]], which re-parses as a premature {{/box}}.
+.#-----------------------------------------------------
+.input|xhtml/1.0
+.#-----------------------------------------------------
+<!--startmacro:box|-||-|[[label>>~\{~\{/box}}]]--><div class="box"><div data-xwiki-non-generated-content="java.util.List&lt;org.xwiki.rendering.block.Block&gt;" class="xwiki-metadata-container"><p><!--startwikilink:false|-|doc|-|\{\{/box}}--><span class="wikicreatelink"><a href="editurl">label</a></span><!--stopwikilink--></p></div></div><!--stopmacro-->
+.#-----------------------------------------------------
+.expect|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+[[label>>~{~{/box}}]]
+{{/box}}

--- a/xwiki-rendering-integration-tests/src/test/resources/wiki/link/links6.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/wiki/link/links6.test
@@ -1,6 +1,8 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
-.# [[{{macro}}]]					a macro as label
+.# [[{{macro}}]]					a macro as label, kept as a plain reference. It is re-serialized escaped
+.#									(~{~{) so that it cannot be parsed as a macro, nor close a macro this link is
+.#									serialized in; the escaped form parses back to the very same reference.
 .# [[Label>Reference]]				just a reference, the > need to be double to be matched as a link syntax
 .# [[Reference|Param=Value]]		just a reference,  the | need to be double to be matched as a link syntax
 .# [[[[no link]]>>Not Reference]]	only images are valid sub-links syntaxes
@@ -59,7 +61,7 @@ endDocument
 .#-----------------------------------------------------
 .expect|xwiki/2.0
 .#-----------------------------------------------------
-[[{{macro}}]]
+[[~{~{macro}}]]
 [[Label>Reference]]
 [[Reference|Param=Value]]
 [[[[no link]]>>Not Reference]]

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -528,8 +528,9 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
     @Override
     public void onId(String name)
     {
-        // Use the macro printer so that the name is escaped like any other macro parameter value.
-        print(getMacroPrinter().renderMacro("id", Map.of("name", name), null, true));
+        // Use the macro printer so that the name is escaped like any other macro parameter value, and the inline
+        // macro printing so that a "{" printed just before isn't parsed as the start of a verbatim block.
+        printInlineMacro(getMacroPrinter().renderMacro("id", Map.of("name", name), null, true));
     }
 
     @Override
@@ -949,6 +950,16 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
 
             print(buffer.toString());
         }
+    }
+
+    private void printInlineMacro(String xwikiSyntaxText)
+    {
+        this.isFirstElementRendered = true;
+
+        // Handle empty formatting parameters.
+        handleEmptyParameters();
+
+        getXWikiPrinter().printInlineMacro(xwikiSyntaxText);
     }
 
     private void printDelayed(String text)

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxChainingRenderer.java
@@ -199,7 +199,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
     {
         // Flush text content before the link.
         // Escape open link syntax when before a link.
-        if (getLinkRenderer().forceFullSyntax(getXWikiPrinter(), freestanding, parameters)
+        if (getLinkRenderer().forceFullSyntax(getXWikiPrinter(), reference, freestanding, parameters)
             && !getXWikiPrinter().getBuffer().isEmpty()
             && getXWikiPrinter().getBuffer().charAt(getXWikiPrinter().getBuffer().length() - 1) == '[')
         {
@@ -208,7 +208,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
         handleEmptyParameters();
         getXWikiPrinter().flush();
 
-        getLinkRenderer().beginRenderLink(getXWikiPrinter(), freestanding, parameters);
+        getLinkRenderer().beginRenderLink(getXWikiPrinter(), reference, freestanding, parameters);
 
         XWikiSyntaxEscapeWikiPrinter linkLabelPrinter =
             new XWikiSyntaxEscapeWikiPrinter(new DefaultWikiPrinter(), getXWikiSyntaxListenerChain());
@@ -528,7 +528,8 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
     @Override
     public void onId(String name)
     {
-        print("{{id name=\"" + name + "\"/}}");
+        // Use the macro printer so that the name is escaped like any other macro parameter value.
+        print(getMacroPrinter().renderMacro("id", Map.of("name", name), null, true));
     }
 
     @Override
@@ -819,7 +820,8 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
                     getBlockState().beginLink(figureContent.getLinkReference(), false,
                         figureContent.getLinkParameters());
                 }
-                getImageRenderer().beginRenderLink(getXWikiPrinter(), false, figureContent.getImageParameters());
+                getImageRenderer().beginRenderLink(getXWikiPrinter(), figureContent.getImageReference(), false,
+                    figureContent.getImageParameters());
 
                 // Ignore output from, e.g., a nested paragraph or anything else that might wrap the image/caption.
                 this.pushPrinter(
@@ -909,7 +911,7 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
     @Override
     public void onImage(ResourceReference reference, boolean freestanding, Map<String, String> parameters)
     {
-        getImageRenderer().beginRenderLink(getXWikiPrinter(), freestanding, parameters);
+        getImageRenderer().beginRenderLink(getXWikiPrinter(), reference, freestanding, parameters);
         getImageRenderer().endRenderLink(getXWikiPrinter(), reference, freestanding, parameters);
     }
 
@@ -930,6 +932,8 @@ public class XWikiSyntaxChainingRenderer extends AbstractChainingPrintRenderer i
                 value = PARAMETER_VALUE_ESCAPES.matcher(value).replaceAll("~$0");
                 // Escape ending custom parameters syntax
                 value = value.replace("%)", "~%)");
+                // Escape anything that could close the macro this value might be serialized in
+                value = XWikiSyntaxEscapeHandler.escapeCurlyBrackets(value);
                 parametersStr.append(' ').append(key).append('=').append('\"').append(value).append('\"');
             }
         }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxEscapeHandler.java
@@ -52,6 +52,12 @@ public class XWikiSyntaxEscapeHandler
     private static final Pattern DOUBLE_CHARS_PATTERN = Pattern.compile(
         "(?<!~)\\/\\/|(?<!~)\\*\\*|(?<!~)__|(?<!~)--|(?<!~)\\^\\^|(?<!~),,|(?<!~)##|(?<!~)\\\\\\\\");
 
+    /**
+     * Matches every "{" that is next to another one, that is every character of a run of two or more "{". A single
+     * "{" has no meaning in XWiki Syntax and is left alone.
+     */
+    private static final Pattern CURLY_BRACKETS_PATTERN = Pattern.compile("\\{(?=\\{)|(?<=\\{)\\{");
+
     public static final String ESCAPE_CHAR = "~";
 
     private boolean onNewLine = true;
@@ -118,11 +124,8 @@ public class XWikiSyntaxEscapeHandler
             replaceAll(accumulatedBuffer, "=", ESCAPE_CHAR + "=");
         }
 
-        // Escape verbatim "{{{"
-        replaceAll(accumulatedBuffer, "{{{", ESCAPE_CHAR + "{" + ESCAPE_CHAR + "{" + ESCAPE_CHAR + "{");
-
-        // Escape "{{"
-        replaceAll(accumulatedBuffer, "{{", ESCAPE_CHAR + "{" + ESCAPE_CHAR + "{");
+        // Escape anything that could be confused with a macro ("{{") or with verbatim content ("{{{").
+        escapeCurlyBrackets(accumulatedBuffer);
 
         // Escape groups
         replaceAll(accumulatedBuffer, "(((", ESCAPE_CHAR + "(" + ESCAPE_CHAR + "(" + ESCAPE_CHAR + "(");
@@ -152,6 +155,40 @@ public class XWikiSyntaxEscapeHandler
 
         // Escape begin link
         replaceAll(accumulatedBuffer, "[[", ESCAPE_CHAR + "[" + ESCAPE_CHAR + "[");
+    }
+
+    /**
+     * Escapes the "{" characters that form a "{{" sequence, so that the passed value cannot be confused with the
+     * start or the end of a macro or with verbatim content when it is parsed again. This is needed for every value
+     * that is serialized as-is inside the content of a macro, as the macro content is scanned for the macro's closing
+     * marker without any regard for the construct the marker appears in.
+     * <p>
+     * Every character of a run of "{" is escaped, so that no "{{" sequence is left in the result whatever the length of
+     * the run. A single "{" is left alone as it has no meaning in XWiki Syntax. Callers must escape the escape
+     * character itself <em>before</em> calling this method, so that the tildes inserted here are not doubled.
+     *
+     * @param value the value to escape
+     * @return the escaped value
+     * @since 16.10.19
+     * @since 17.10.14
+     * @since 18.4.6
+     * @since 18.8.0RC1
+     */
+    public static String escapeCurlyBrackets(String value)
+    {
+        return CURLY_BRACKETS_PATTERN.matcher(value).replaceAll(ESCAPE_CHAR + "$0");
+    }
+
+    /**
+     * Same as {@link #escapeCurlyBrackets(String)} but modifying the passed buffer in place.
+     *
+     * @param accumulatedBuffer the buffer to escape
+     */
+    private static void escapeCurlyBrackets(StringBuffer accumulatedBuffer)
+    {
+        String escaped = escapeCurlyBrackets(accumulatedBuffer.toString());
+        accumulatedBuffer.setLength(0);
+        accumulatedBuffer.append(escaped);
     }
 
     private void escapeURI(StringBuffer accumulatedBuffer, String match)

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/reference/XWikiSyntaxResourceRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/main/java/org/xwiki/rendering/internal/renderer/xwiki20/reference/XWikiSyntaxResourceRenderer.java
@@ -28,6 +28,7 @@ import org.apache.commons.text.translate.CharSequenceTranslator;
 import org.apache.commons.text.translate.LookupTranslator;
 import org.xwiki.rendering.internal.parser.plain.PlainTextStreamParser;
 import org.xwiki.rendering.internal.renderer.ParametersPrinter;
+import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxEscapeHandler;
 import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxEscapeWikiPrinter;
 import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxListenerChain;
 import org.xwiki.rendering.listener.QueueListener.Event;
@@ -75,21 +76,82 @@ public class XWikiSyntaxResourceRenderer
         this.forceFullSyntaxDeque.push(false);
     }
 
+    /**
+     * Serializes a resource reference into the string that represents it in XWiki Syntax.
+     * <p>
+     * A reference printed inside the full syntax is escaped so that it can neither end the reference early ("~", ">>",
+     * "||" and "]]") nor close the macro it might be serialized in ("{{"). A free-standing reference cannot be escaped
+     * at all, so it is returned as-is, which is why a reference that would need escaping isn't printed free-standing
+     * in the first place.
+     *
+     * @param reference the reference to serialize
+     * @param isFreeStanding {@code true} if the reference is printed without the surrounding {@code [[]]}, in which
+     *     case no escaping is applied
+     * @return the string representation of the reference
+     */
     public String serialize(ResourceReference reference, boolean isFreeStanding)
     {
         String result = this.referenceSerializer.serialize(reference);
 
         if (!isFreeStanding) {
-            result = result.replace("~", "~~")
+            result = XWikiSyntaxEscapeHandler.escapeCurlyBrackets(result.replace("~", "~~")
                 .replace(">>", "~>~>")
                 .replace(PARAMETER_SEPARATOR, "~|~|")
-                .replace("]]", "~]~]");
+                .replace("]]", "~]~]"));
         }
 
         return result;
     }
 
-    public void beginRenderLink(XWikiSyntaxEscapeWikiPrinter printer,
+    /**
+     * Checks whether printing the reference as a free-standing reference could produce a "{{" in the output.
+     * <p>
+     * A "{{" is not rejected here because the reference wouldn't survive it. Quite the contrary: the image and the
+     * attachment tokens of the parser accept every character but white space, so a free-standing "image:a{{b.png"
+     * parses back to the very same reference. A free-standing URL is indeed truncated at the "{", as the URI token
+     * accepts no "{", but that is the fate it shares with the many other characters the URI token doesn't accept
+     * either - a "}" or a "," for instance - and that general limitation of free-standing URLs is not what this
+     * method is about.
+     * <p>
+     * What makes a "{{" special is that the content of a macro is scanned for the macro's closing marker without any
+     * regard for the construct that marker appears in. A "{{" printed inside a free-standing reference can thus close
+     * the macro this reference is serialized in and break the structure of the whole document. Every other value that
+     * the renderer prints as-is is escaped to prevent that, but a free-standing reference cannot be escaped, so the
+     * full syntax is the only way out. As references containing a "{{" are rare, that is a small price to pay.
+     *
+     * @param reference the reference to check
+     * @return {@code true} if printing the reference as a free-standing reference could produce a "{{" in the output
+     */
+    private boolean mayProduceMacroSyntax(ResourceReference reference)
+    {
+        if (reference == null) {
+            return false;
+        }
+
+        String serializedReference = serialize(reference, true);
+
+        // A leading "{" forms a "{{" with a "{" that has been printed just before the reference. Rather than
+        // inspecting the output printed so far, always use the full syntax then - a free-standing reference starting
+        // with a "{" is broken anyway.
+        return serializedReference.contains("{{") || serializedReference.startsWith("{");
+    }
+
+    /**
+     * Starts printing a link or an image by printing the {@code [[} that opens the full syntax, unless the reference
+     * can be printed free-standing. Whether the full syntax is used is remembered until the matching
+     * {@link #endRenderLink(XWikiSyntaxEscapeWikiPrinter, ResourceReference, boolean, Map)} call.
+     *
+     * @param printer the printer to print to
+     * @param reference the reference that is going to be printed
+     * @param freestanding {@code true} if the reference was written without the {@code [[]]} syntax in the first
+     *     place, which is only a request as the full syntax can still be forced
+     * @param parameters the parameters of the link or image
+     * @since 16.10.19
+     * @since 17.10.14
+     * @since 18.4.6
+     * @since 18.8.0RC1
+     */
+    public void beginRenderLink(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference reference,
         boolean freestanding, Map<String, String> parameters)
     {
         // find if the last printed char is part of a syntax (i.e. consumed by the parser before starting to parse the
@@ -98,7 +160,7 @@ public class XWikiSyntaxResourceRenderer
 
         printer.flush();
 
-        if (forceFullSyntax(printer, isLastSyntax, freestanding, parameters)) {
+        if (forceFullSyntax(printer, reference, isLastSyntax, freestanding, parameters)) {
             this.forceFullSyntaxDeque.push(true);
 
             printer.print("[[");
@@ -107,14 +169,45 @@ public class XWikiSyntaxResourceRenderer
         }
     }
 
-    public boolean forceFullSyntax(XWikiSyntaxEscapeWikiPrinter printer, boolean freestanding,
-        Map<String, String> parameters)
+    /**
+     * Same as {@link #forceFullSyntax(XWikiSyntaxEscapeWikiPrinter, ResourceReference, boolean, boolean, Map)} with
+     * {@code isLastSyntax} set to {@code true}.
+     *
+     * @param printer the printer the reference is going to be printed to
+     * @param reference the reference that is going to be printed
+     * @param freestanding {@code true} if the reference was written without the {@code [[]]} syntax
+     * @param parameters the parameters of the link or image
+     * @return {@code true} if the full {@code [[]]} syntax needs to be used
+     * @since 16.10.19
+     * @since 17.10.14
+     * @since 18.4.6
+     * @since 18.8.0RC1
+     */
+    public boolean forceFullSyntax(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference reference,
+        boolean freestanding, Map<String, String> parameters)
     {
-        return forceFullSyntax(printer, true, freestanding, parameters);
+        return forceFullSyntax(printer, reference, true, freestanding, parameters);
     }
 
-    public boolean forceFullSyntax(XWikiSyntaxEscapeWikiPrinter printer, boolean isLastSyntax,
-        boolean freestanding, Map<String, String> parameters)
+    /**
+     * Checks whether the reference has to be printed with the full {@code [[]]} syntax, either because the reference
+     * wasn't free-standing in the first place, or because printing it free-standing wouldn't produce a document that
+     * parses back to the same content.
+     *
+     * @param printer the printer the reference is going to be printed to
+     * @param reference the reference that is going to be printed
+     * @param isLastSyntax {@code true} if the last character printed is part of a syntax construct, that is one
+     *     consumed by the parser before it starts parsing the reference
+     * @param freestanding {@code true} if the reference was written without the {@code [[]]} syntax
+     * @param parameters the parameters of the link or image
+     * @return {@code true} if the full {@code [[]]} syntax needs to be used
+     * @since 16.10.19
+     * @since 17.10.14
+     * @since 18.4.6
+     * @since 18.8.0RC1
+     */
+    public boolean forceFullSyntax(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference reference,
+        boolean isLastSyntax, boolean freestanding, Map<String, String> parameters)
     {
         Event nextEvent = this.listenerChain.getLookaheadChainingListener().getNextEvent();
 
@@ -125,10 +218,13 @@ public class XWikiSyntaxResourceRenderer
         // a another link)
         // 4: it's followed by a character which is not a white space (TODO: find a better way than this endless list of
         // EventType test but it probably need some big refactoring of the printer and XWikiSyntaxResourceRenderer)
+        // 5: printing the reference free-standing could produce a "{{" in the output, which could close the macro
+        // this reference is serialized in and which cannot be escaped in a free-standing reference
         return !freestanding
             || !parameters.isEmpty()
             || isNonWhiteSpaceAndConsumed(isLastSyntax, printer)
-            || isNotAWhiteSpace(nextEvent);
+            || isNotAWhiteSpace(nextEvent)
+            || mayProduceMacroSyntax(reference);
     }
 
     private boolean isNonWhiteSpaceAndConsumed(boolean isLastSyntax, XWikiSyntaxEscapeWikiPrinter printer)
@@ -156,28 +252,51 @@ public class XWikiSyntaxResourceRenderer
         }
     }
 
+    /**
+     * Finishes printing a link or an image by printing its reference, its parameters and, when the full syntax is used,
+     * the closing {@code ]]}.
+     *
+     * @param printer the printer to print to
+     * @param reference the reference to print
+     * @param freestanding {@code true} if the reference was written without the {@code [[]]} syntax in the first
+     *     place; whether the full syntax is actually used has been decided by
+     *     {@link #beginRenderLink(XWikiSyntaxEscapeWikiPrinter, ResourceReference, boolean, Map)}
+     * @param parameters the parameters of the link or image
+     */
     public void endRenderLink(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference reference,
         boolean freestanding, Map<String, String> parameters)
     {
-        printer.print(serialize(reference, freestanding));
+        // The reference is only left unescaped when it is actually printed as a free-standing reference, as escaping
+        // is not possible there. beginRenderLink() already took the "!freestanding" case into account when it pushed
+        // this flag, so both decisions come from the very same place.
+        boolean fullSyntax = this.forceFullSyntaxDeque.peek();
+
+        printer.print(serialize(reference, !fullSyntax));
 
         // If there were parameters specified, print them
         printParameters(printer, reference, parameters);
 
-        if (this.forceFullSyntaxDeque.peek() || !freestanding) {
+        if (fullSyntax) {
             printer.print("]]");
         }
 
         this.forceFullSyntaxDeque.pop();
     }
 
+    /**
+     * Prints the parameters of a link or an image, separated from the reference by the parameter separator.
+     *
+     * @param printer the printer to print to
+     * @param resourceReference the reference the parameters belong to
+     * @param parameters the parameters to print
+     */
     protected void printParameters(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference resourceReference,
         Map<String, String> parameters)
     {
         // If there were parameters specified, output them separated by the "||" characters
         if (!parameters.isEmpty()) {
             printer.print(PARAMETER_SEPARATOR);
-            printer.print(PARAMETERS_PRINTER.print(parameters));
+            printer.print(XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(parameters)));
         }
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxBlockRendererTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxBlockRendererTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.renderer.xwiki20;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,15 +32,18 @@ import org.xwiki.rendering.block.DefinitionListBlock;
 import org.xwiki.rendering.block.DefinitionTermBlock;
 import org.xwiki.rendering.block.GroupBlock;
 import org.xwiki.rendering.block.HeaderBlock;
+import org.xwiki.rendering.block.IdBlock;
 import org.xwiki.rendering.block.ListItemBlock;
 import org.xwiki.rendering.block.NewLineBlock;
 import org.xwiki.rendering.block.ParagraphBlock;
 import org.xwiki.rendering.block.SectionBlock;
+import org.xwiki.rendering.block.SpecialSymbolBlock;
 import org.xwiki.rendering.block.TableBlock;
 import org.xwiki.rendering.block.TableCellBlock;
 import org.xwiki.rendering.block.TableHeadCellBlock;
 import org.xwiki.rendering.block.TableRowBlock;
 import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.HeaderLevel;
 import org.xwiki.rendering.renderer.BlockRenderer;
 import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
@@ -73,6 +77,21 @@ class XWikiSyntaxBlockRendererTest
     void inline()
     {
         assertEquals("word", render(new WordBlock("word")));
+    }
+
+    @Test
+    void idAfterCurlyBracket()
+    {
+        // The "{" needs to be escaped, otherwise the output would start with "{{{" and be parsed as a verbatim block.
+        Block paragraph = new ParagraphBlock(List.of(new SpecialSymbolBlock('{'), new IdBlock("anchor")));
+        assertEquals("~{{{id name=\"anchor\"/}}", render(paragraph));
+    }
+
+    @Test
+    void standaloneIdFollowedByParagraph()
+    {
+        Block xdom = new XDOM(List.of(new IdBlock("anchor"), new ParagraphBlock(List.of(new WordBlock("word")))));
+        assertEquals("{{id name=\"anchor\"/}}\n\nword", render(xdom));
     }
 
     @Test

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxFreeStandingReferenceTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxFreeStandingReferenceTest.java
@@ -1,0 +1,149 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.renderer.xwiki20;
+
+import java.io.StringReader;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.LinkBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.ClassBlockMatcher;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+import org.xwiki.rendering.parser.Parser;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a free-standing reference containing a "{{" survives a render-parse round-trip. A free-standing
+ * reference is printed as-is, without any escaping, so the renderer has to fall back to the full {@code [[...]]}
+ * syntax whenever printing the reference free-standing could produce a "{{" in the output, which could close the
+ * macro the reference is serialized in.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@AllComponents
+class XWikiSyntaxFreeStandingReferenceTest
+{
+    @InjectComponentManager
+    private ComponentManager componentManager;
+
+    private String render(Block block) throws Exception
+    {
+        BlockRenderer renderer =
+            this.componentManager.getInstance(BlockRenderer.class, Syntax.XWIKI_2_0.toIdString());
+        DefaultWikiPrinter printer = new DefaultWikiPrinter();
+        renderer.render(block, printer);
+
+        return printer.toString().trim();
+    }
+
+    private XDOM parse(String content) throws Exception
+    {
+        Parser parser = this.componentManager.getInstance(Parser.class, Syntax.XWIKI_2_0.toIdString());
+
+        return parser.parse(new StringReader(content));
+    }
+
+    private static ResourceReference untypedURL(String reference)
+    {
+        ResourceReference result = new ResourceReference(reference, ResourceType.URL);
+        result.setTyped(false);
+
+        return result;
+    }
+
+    private String assertReferenceRoundTrips(String reference) throws Exception
+    {
+        String content = render(new XDOM(
+            List.of(new ParagraphBlock(List.of(new LinkBlock(List.of(), untypedURL(reference), true))))));
+
+        List<LinkBlock> links =
+            parse(content).getBlocks(new ClassBlockMatcher(LinkBlock.class), Block.Axes.DESCENDANT);
+
+        assertEquals(1, links.size(), "The reference didn't round-trip to a single link. Rendered content was ["
+            + content + "]");
+        assertEquals(reference, links.get(0).getReference().getReference(),
+            "The reference changed during the round-trip. Rendered content was [" + content + "]");
+
+        return content;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // A "{{" closes the macro the reference might be serialized in.
+        "http://example.com/{{/info}}",
+        "{{macro}}http://example.com/",
+        // A run of "{" longer than two must be escaped completely, no "{{" may be left behind.
+        "http://example.com/{{{{{x",
+        // A leading "{" forms a "{{" with a "{" that has been printed just before the reference.
+        "{x://example.com/",
+        // Characters that the full syntax escapes must not be lost when the full syntax is forced by the "{{".
+        "http://example.com/a~b{{x}}",
+        "http://example.com/a]]b{{x}}",
+        "http://example.com/a>>b{{x}}",
+        "http://example.com/a||b{{x}}"
+    })
+    void referenceNeedingTheFullSyntax(String reference) throws Exception
+    {
+        String content = assertReferenceRoundTrips(reference);
+
+        assertTrue(content.startsWith("[[") && content.endsWith("]]"),
+            "The reference wasn't printed with the full syntax: [" + content + "]");
+    }
+
+    @Test
+    void referenceStayingFreeStanding() throws Exception
+    {
+        // A "~" is not unescaped in a free-standing reference, so it must stay unescaped and must not force the full
+        // syntax.
+        String reference = "http://example.com/a~b";
+
+        assertEquals(reference, assertReferenceRoundTrips(reference));
+    }
+
+    @Test
+    void referenceWithASingleCurlyBracketStaysFreeStanding() throws Exception
+    {
+        // A single "{" cannot close a macro, so it doesn't force the full syntax. That the URI token stops at it and
+        // thus truncates the reference when it is parsed again is a limitation which it shares with every other
+        // character the URI token doesn't accept (a "}" or a "," for instance).
+        String reference = "http://example.com/a{b";
+
+        String content = render(new XDOM(
+            List.of(new ParagraphBlock(List.of(new LinkBlock(List.of(), untypedURL(reference), true))))));
+
+        assertEquals(reference, content);
+    }
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxMacroContentRoundTripTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki20/src/test/java/org/xwiki/rendering/internal/renderer/xwiki20/XWikiSyntaxMacroContentRoundTripTest.java
@@ -1,0 +1,181 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.renderer.xwiki20;
+
+import java.io.StringReader;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.IdBlock;
+import org.xwiki.rendering.block.ImageBlock;
+import org.xwiki.rendering.block.LinkBlock;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+import org.xwiki.rendering.parser.Parser;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that content produced by the XWiki Syntax 2.0 renderer for the body of a macro survives a
+ * parse-render-parse round-trip: leaf values (macro/group parameters, resource references) which happen to contain
+ * the {@code {{/macro}}} sequence are escaped so that they cannot prematurely close the enclosing macro. This
+ * round-trip is exercised by the WYSIWYG editor (annotated XHTML) and by link refactoring, both of which re-parse and
+ * re-render macro content.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@AllComponents
+class XWikiSyntaxMacroContentRoundTripTest
+{
+    private Parser parser;
+
+    private BlockRenderer renderer;
+
+    @BeforeEach
+    void before(ComponentManager componentManager) throws Exception
+    {
+        this.parser = componentManager.getInstance(Parser.class, Syntax.XWIKI_2_0.toIdString());
+        this.renderer = componentManager.getInstance(BlockRenderer.class, Syntax.XWIKI_2_0.toIdString());
+    }
+
+    private String render(Block block)
+    {
+        DefaultWikiPrinter printer = new DefaultWikiPrinter();
+        this.renderer.render(block, printer);
+
+        return printer.toString();
+    }
+
+    /**
+     * Renders {@code innerSyntax} as it would be stored as the content of a {@code macroName} macro (this is what the
+     * WYSIWYG editor and link refactoring do), puts it back inside the macro, parses again, and asserts that the macro
+     * still holds the same content instead of having been closed early by the injected content.
+     */
+    private void assertMacroContentRoundTrips(String macroName, String innerSyntax) throws Exception
+    {
+        assertRenderedContentRoundTrips(macroName, this.parser.parse(new StringReader(innerSyntax)));
+    }
+
+    /**
+     * Same as {@link #assertMacroContentRoundTrips(String, String)} for content that cannot be expressed in XWiki
+     * Syntax in the first place, like a free-standing reference that needs escaping.
+     */
+    private void assertMacroContentRoundTrips(String macroName, Block... innerBlocks) throws Exception
+    {
+        assertRenderedContentRoundTrips(macroName, new XDOM(List.of(innerBlocks)));
+    }
+
+    private void assertRenderedContentRoundTrips(String macroName, XDOM innerXDOM) throws Exception
+    {
+        // What the renderer produces for the inner blocks: the string stored as the macro content.
+        String content = render(innerXDOM);
+
+        // Put that content back inside the macro and parse it again, as happens on the next view/save.
+        XDOM roundTripped =
+            this.parser.parse(new StringReader("{{" + macroName + "}}\n" + content + "\n{{/" + macroName + "}}"));
+
+        List<MacroBlock> macros = roundTripped.getBlocks(new MacroBlockMatcher(macroName), Block.Axes.DESCENDANT);
+
+        assertEquals(1, macros.size(),
+            "The [" + macroName + "] macro broke apart during the round-trip. Rendered content was [" + content + "]");
+        assertEquals(macroName, macros.get(0).getId());
+        // The macro content must still mean the same thing (compare via a normalising render).
+        assertEquals(content, render(this.parser.parse(new StringReader(macros.get(0).getContent()))),
+            "The macro content changed meaning during the round-trip. Rendered content was [" + content + "]");
+    }
+
+    @Test
+    void groupParameterContainingMacroClose() throws Exception
+    {
+        assertMacroContentRoundTrips("info", "(% class=\"{{/info}}\" %)Info content");
+    }
+
+    @Test
+    void linkReferenceContainingMacroClose() throws Exception
+    {
+        assertMacroContentRoundTrips("info", "[[label>>{{/info}}]]");
+    }
+
+    @Test
+    void textContainingMacroCloseInCurlyBracketRun() throws Exception
+    {
+        // The text is "{{{{{/info}}": a run of curly brackets long enough that escaping only the pairs would leave a
+        // "{{" behind.
+        assertMacroContentRoundTrips("info", "~{~{~{~{~{/info}}");
+    }
+
+    @Test
+    void linkParameterContainingMacroClose() throws Exception
+    {
+        assertMacroContentRoundTrips("info", "[[label>>Space.Page||class=\"{{/info}}\"]]");
+    }
+
+    @Test
+    void freestandingReferenceContainingMacroClose() throws Exception
+    {
+        // A free-standing reference cannot be escaped, so the renderer has to fall back to the full link syntax.
+        assertMacroContentRoundTrips("info", new ParagraphBlock(List.of(new LinkBlock(List.of(),
+            new ResourceReference("http://example.com/{{/info}}", ResourceType.URL), true))));
+    }
+
+    @Test
+    void freestandingImageReferenceContainingMacroClose() throws Exception
+    {
+        // The image token of the parser accepts a "{{", so the reference would survive it outside of a macro, but it
+        // would still close the macro, hence the fall back to the full image syntax.
+        ResourceReference reference = new ResourceReference("http://example.com/{{/info}}.png", ResourceType.URL);
+        reference.setTyped(false);
+
+        assertMacroContentRoundTrips("info", new ParagraphBlock(List.of(new ImageBlock(reference, true))));
+    }
+
+    @Test
+    void idContainingMacroCloseAndQuote() throws Exception
+    {
+        assertMacroContentRoundTrips("info", new ParagraphBlock(List.of(new IdBlock("anchor\"{{/info}}"))));
+    }
+
+    @Test
+    void linkLabelContainingMacroKeepsTheMacro() throws Exception
+    {
+        String innerSyntax = "[[{{id name=\"anchor\"/}}>>Space.Page]]";
+
+        assertMacroContentRoundTrips("info", innerSyntax);
+
+        // The label is passed to the resource renderer as already rendered XWiki Syntax, so a "{{" in it is a real
+        // macro and must not be escaped.
+        String content = render(this.parser.parse(new StringReader(innerSyntax)));
+        assertTrue(content.contains("{{id"), "The macro of the link label was escaped: [" + content + "]");
+    }
+}

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/main/java/org/xwiki/rendering/internal/renderer/xwiki21/reference/XWikiSyntaxResourceRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/main/java/org/xwiki/rendering/internal/renderer/xwiki21/reference/XWikiSyntaxResourceRenderer.java
@@ -22,6 +22,7 @@ package org.xwiki.rendering.internal.renderer.xwiki21.reference;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxEscapeHandler;
 import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxEscapeWikiPrinter;
 import org.xwiki.rendering.internal.renderer.xwiki20.XWikiSyntaxListenerChain;
 import org.xwiki.rendering.listener.reference.AttachmentResourceReference;
@@ -71,6 +72,16 @@ public class XWikiSyntaxResourceRenderer
         return ResourceType.ATTACHMENT.equals(resourceType) || ResourceType.PAGE_ATTACHMENT.equals(resourceType);
     }
 
+    /**
+     * @param name the name of the reference parameter to print
+     * @param value the value of the reference parameter to print
+     * @return the printed parameter, escaped so that it cannot close a macro it might be serialized in
+     */
+    private static String printParameter(String name, String value)
+    {
+        return XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(name, value, '~'));
+    }
+
     @Override
     protected void printParameters(XWikiSyntaxEscapeWikiPrinter printer, ResourceReference reference,
         Map<String, String> parameters)
@@ -88,7 +99,7 @@ public class XWikiSyntaxResourceRenderer
             String queryString = reference.getParameter(DocumentResourceReference.QUERY_STRING);
             if (!StringUtils.isEmpty(queryString)) {
                 printer.print(PARAMETER_SEPARATOR);
-                printer.print(PARAMETERS_PRINTER.print(QUERY_STRING, queryString, '~'));
+                printer.print(printParameter(QUERY_STRING, queryString));
                 shouldPrintSeparator = false;
             }
             // Then print the anchor
@@ -99,14 +110,14 @@ public class XWikiSyntaxResourceRenderer
                 } else {
                     printer.print(" ");
                 }
-                printer.print(PARAMETERS_PRINTER.print(ANCHOR, anchor, '~'));
+                printer.print(printParameter(ANCHOR, anchor));
                 shouldPrintSeparator = false;
             }
         } else if (isAttachment(resourceType)) {
             String queryString = reference.getParameter(AttachmentResourceReference.QUERY_STRING);
             if (!StringUtils.isEmpty(queryString)) {
                 printer.print(PARAMETER_SEPARATOR);
-                printer.print(PARAMETERS_PRINTER.print(QUERY_STRING, queryString, '~'));
+                printer.print(printParameter(QUERY_STRING, queryString));
                 shouldPrintSeparator = false;
             }
         }
@@ -118,7 +129,7 @@ public class XWikiSyntaxResourceRenderer
             } else {
                 printer.print(" ");
             }
-            printer.print(PARAMETERS_PRINTER.print(parameters, '~'));
+            printer.print(XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(parameters, '~')));
         }
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/main/java/org/xwiki/rendering/internal/renderer/xwiki21/reference/XWikiSyntaxResourceRenderer.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/main/java/org/xwiki/rendering/internal/renderer/xwiki21/reference/XWikiSyntaxResourceRenderer.java
@@ -79,7 +79,7 @@ public class XWikiSyntaxResourceRenderer
      */
     private static String printParameter(String name, String value)
     {
-        return XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(name, value, '~'));
+        return XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(name, value));
     }
 
     @Override
@@ -129,7 +129,7 @@ public class XWikiSyntaxResourceRenderer
             } else {
                 printer.print(" ");
             }
-            printer.print(XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(parameters, '~')));
+            printer.print(XWikiSyntaxEscapeHandler.escapeCurlyBrackets(PARAMETERS_PRINTER.print(parameters)));
         }
     }
 }

--- a/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/test/java/org/xwiki/rendering/internal/renderer/xwiki21/XWikiSyntaxMacroContentRoundTripTest.java
+++ b/xwiki-rendering-syntaxes/xwiki-rendering-syntax-xwiki21/src/test/java/org/xwiki/rendering/internal/renderer/xwiki21/XWikiSyntaxMacroContentRoundTripTest.java
@@ -1,0 +1,129 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.renderer.xwiki21;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.LinkBlock;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+import org.xwiki.rendering.listener.reference.DocumentResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.parser.Parser;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the reference parameters that are specific to XWiki Syntax 2.1 (the query string and the anchor of a
+ * document reference) survive a render-parse-render round-trip when they carry the closing marker of the macro they are
+ * serialized in. See {@code XWikiSyntaxMacroContentRoundTripTest} of the XWiki Syntax 2.0 module for the carriers that
+ * both syntaxes share.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@AllComponents
+class XWikiSyntaxMacroContentRoundTripTest
+{
+    private static final String MACRO_NAME = "info";
+
+    private static final String MACRO_CLOSE = "{{/info}}";
+
+    @Inject
+    @Named("xwiki/2.1")
+    private Parser parser;
+
+    @Inject
+    @Named("xwiki/2.1")
+    private BlockRenderer renderer;
+
+    private String render(Block block)
+    {
+        DefaultWikiPrinter printer = new DefaultWikiPrinter();
+        this.renderer.render(block, printer);
+
+        return printer.toString();
+    }
+
+    /**
+     * Renders the passed blocks as they would be stored as the content of the macro, puts that content back inside the
+     * macro, parses again and asserts that the macro still holds the same content instead of having been closed early
+     * by the injected content.
+     */
+    private void assertMacroContentRoundTrips(Block... innerBlocks) throws Exception
+    {
+        String content = render(new XDOM(List.of(innerBlocks)));
+
+        XDOM roundTripped = this.parser
+            .parse(new StringReader("{{" + MACRO_NAME + "}}\n" + content + "\n{{/" + MACRO_NAME + "}}"));
+
+        List<MacroBlock> macros = roundTripped.getBlocks(new MacroBlockMatcher(MACRO_NAME), Block.Axes.DESCENDANT);
+
+        assertEquals(1, macros.size(),
+            "The [" + MACRO_NAME + "] macro broke apart during the round-trip. Rendered content was [" + content + "]");
+        assertEquals(content, render(this.parser.parse(new StringReader(macros.get(0).getContent()))),
+            "The macro content changed meaning during the round-trip. Rendered content was [" + content + "]");
+    }
+
+    private static ParagraphBlock paragraphWithLink(ResourceReference reference, Map<String, String> parameters)
+    {
+        return new ParagraphBlock(
+            List.of(new LinkBlock(List.of(new WordBlock("label")), reference, false, parameters)));
+    }
+
+    @Test
+    void queryStringContainingMacroClose() throws Exception
+    {
+        DocumentResourceReference reference = new DocumentResourceReference("Space.Page");
+        reference.setQueryString("parameter=" + MACRO_CLOSE);
+
+        assertMacroContentRoundTrips(paragraphWithLink(reference, Map.of()));
+    }
+
+    @Test
+    void anchorContainingMacroClose() throws Exception
+    {
+        DocumentResourceReference reference = new DocumentResourceReference("Space.Page");
+        reference.setAnchor(MACRO_CLOSE);
+
+        assertMacroContentRoundTrips(paragraphWithLink(reference, Map.of()));
+    }
+
+    @Test
+    void linkParameterContainingMacroClose() throws Exception
+    {
+        assertMacroContentRoundTrips(
+            paragraphWithLink(new DocumentResourceReference("Space.Page"), Map.of("class", MACRO_CLOSE)));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-815

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Escape the "{" runs of every value that the renderer serializes as-is:
    * (%...%) parameter values
    * link and image references, their parameters, and the xwiki/2.1 queryString and anchor reference parameters
    * the id macro name, which had no escaping at all and could also be broken by a quote in the name
* Introduce XWikiSyntaxEscapeHandler#escapeCurlyBrackets as escaping helper that correctly escapes every character of a run of "{" instead of only the pairs: the previous two-pass "{{{"-then-"{{" replacement corrupted runs of four "{" and left a literal "{{" behind for runs of five, so it could still break out of a macro.
* For free-standing references which cannot be escaped at all, fall back to the full [[...]] syntax when printing the reference free-standing would put a "{{" into the output, as that could close the macro the reference is serialized in. This is only about the macro syntax: the image and attachment tokens of the parser accept a "{{" and parse such a reference back unchanged, and where they don't - the URI token accepts no "{" at all - the reference is truncated just like by every other character that token rejects (a "}" or a "," for instance). That pre-existing limitation of free-standing references is not addressed here.
* Correctly escape the reference of links that were initially freestanding when forced into the full syntax.
* Expect [[~{~{macro}}]] in links6.test: the escaped form parses back to the very same reference while the previous output could badly interfere with outer macro syntax.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This fixes more than the original issue description, the general aim of this is to improve the correctness of the XWiki syntax renderer to make parse-render roundtrips correct.
* Both bug investigation and implementation were mostly done by Claude Opus 5 (1M context) <noreply@anthropic.com> with some guidance and review from my side.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Whole `xwiki-rendering` with quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
  * stable-16.10.x