### PR TITLE
XRENDERING-817: Closing macro syntax in verbatim content can close surrounding macro

### DIFF
--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro40.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro40.test
@@ -1,0 +1,26 @@
+.#-----------------------------------------------------
+.# A verbatim block inside a box macro contains the macro's own closing marker
+.# ({{/box}}). Unlike a parameter value or a reference (macro38/macro39),
+.# verbatim content is literal, it cannot be escaped.
+.# 
+.# Note: a verbatim that starts with a word ({{{Verbatim ...) is accidentally
+.# protected by the lexer's maximal-munch ({{Verbatim {{/box}} is swallowed 
+.# as a nested-macro start), which is why the leading space matters here.
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+{{{ {{/box}} }}}
+{{/box}}
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.#-----------------------------------------------------
+{{box}}
+{{{ {{/box}} }}}
+{{/box}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [box] [] [{{{ {{/box}} }}}]
+endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro41.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro41.test
@@ -1,0 +1,35 @@
+.#-----------------------------------------------------
+.# An unterminated verbatim inside a macro must keep closing the macro at its closing marker, as it did before
+.# MACRO_CONTEXT became verbatim-aware: the MACRO_VERBATIM_LOOKAHEAD token only treats a "{{{" as the start of a
+.# verbatim block if that block is actually closed, so that a stray "{{{" cannot swallow the rest of the document.
+.# See macro44 for the case where a later, unrelated "}}}" does make the look-ahead match.
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+{{{ unterminated
+{{/box}}
+
+After the box.
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.#-----------------------------------------------------
+{{box}}
+{{{ unterminated
+{{/box}}
+
+After the box.
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [box] [] [{{{ unterminated]
+beginParagraph
+onWord [After]
+onSpace
+onWord [the]
+onSpace
+onWord [box]
+onSpecialSymbol [.]
+endParagraph
+endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro42.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro42.test
@@ -1,0 +1,23 @@
+.#-----------------------------------------------------
+.# Like macro40, but with the macro's closing marker inside a *nested* verbatim block, which is what the renderer
+.# produces for verbatim content that itself contains "{{{...}}}" (see XWikiSyntaxEscapeWikiPrinter#printVerbatimContent).
+.# The verbatim nesting has to be counted, otherwise the region would end at the first "}}}" and the following
+.# "{{/box}}" would close the macro early.
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+{{{a{{{b}}}{{/box}}c}}}
+{{/box}}
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.#-----------------------------------------------------
+{{box}}
+{{{a{{{b}}}{{/box}}c}}}
+{{/box}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [box] [] [{{{a{{{b}}}{{/box}}c}}}]
+endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro43.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro43.test
@@ -1,0 +1,22 @@
+.#-----------------------------------------------------
+.# An escaped closing marker does not close the macro, because "~{" is matched as a single MACRO_CONTENT token
+.# (XWIKI_SPECIAL_SYMBOL covers "~" followed by a special symbol). This also keeps an escaped "~{{{" from being
+.# recognized as the start of a verbatim block by MACRO_VERBATIM_LOOKAHEAD.
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+~{{/box}}
+{{/box}}
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.#-----------------------------------------------------
+{{box}}
+~{{/box}}
+{{/box}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [box] [] [~{{/box}}]
+endDocument

--- a/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro44.test
+++ b/xwiki-rendering-integration-tests/src/test/resources/simple/macros/macro44.test
@@ -1,0 +1,33 @@
+.#-----------------------------------------------------
+.# Known limitation of the verbatim-aware macro content scan: whether an unterminated "{{{" inside a macro is
+.# verbatim or not is genuinely ambiguous, and MACRO_VERBATIM_LOOKAHEAD resolves it by looking for a "}}}" anywhere
+.# after it. Here the "{{{elsewhere}}}" that follows the macro provides one, so the "{{{" is taken as a verbatim
+.# block and the macro's closing marker is scanned as verbatim content instead of closing the box.
+.# Before the parser became verbatim-aware the box closed at its marker (as it still does in macro41). This is the
+.# accepted trade-off of the fix, not an intended behaviour: any resolution of the ambiguity breaks one of the two
+.# readings.
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.#-----------------------------------------------------
+{{box}}
+{{{ unterminated
+{{/box}}
+
+{{{elsewhere}}}
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.#-----------------------------------------------------
+{{box}}
+{{{ unterminated
+{{/box}}
+
+{{{elsewhere}}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+onMacroStandalone [box] [] [{{{ unterminated
+{{/box}}
+
+{{{elsewhere}}}]
+endDocument

--- a/xwiki-rendering-wikimodel/src/main/javacc/XWiki20Scanner.jj
+++ b/xwiki-rendering-wikimodel/src/main/javacc/XWiki20Scanner.jj
@@ -208,9 +208,11 @@ TOKEN_MGR_DECLS: {
     int tableDepth = 0; 
     String macroName = "";
     int macroDepth = 0;
+    int macroVerbatimDepth = 0;
     void initMacro(CharSequence buf) {
         macroName = getMacroName(buf);
         macroDepth = 1;
+        macroVerbatimDepth = 0;
     }
     String getMacroName(CharSequence buf) {
         Matcher matcher = MACRO_NAME_PATTERN.matcher(buf);
@@ -409,8 +411,52 @@ TOKEN_MGR_DECLS: {
             }
         }
     }
+    /*
+     * Verbatim content is literal, so the closing marker of the macro must not be recognized inside it. This token is
+     * only a look-ahead checking that the verbatim block is actually closed: all of it but the opening "{{{" is backed
+     * up and rescanned in MACRO_VERBATIM_CONTEXT, which counts the nesting. An unterminated "{{{" doesn't match here
+     * and is scanned character by character as before, so that it cannot swallow the rest of the document.
+     */
+    | <MACRO_VERBATIM_LOOKAHEAD: "{{{" ( "~" ~[] | ~["}", "~"] | "}" ~["}", "~"] | "}}" ~["}", "~"] )* "}}}" > {
+        {
+            input_stream.backup(image.length() - "{{{".length());
+            matchedToken.image = "{{{";
+            matchedToken.kind = MACRO_CONTENT;
+            macroVerbatimDepth = 1;
+        }
+      } : MACRO_VERBATIM_CONTEXT
     | <MACRO_CONTENT: ( <XWIKI_CHAR> | <SPACE> |<NEW_LINE> | <XWIKI_SPECIAL_SYMBOL> ) >
 
+}
+
+/*
+ * Scans the verbatim blocks that appear inside the content of a macro. Everything is reported as MACRO_CONTENT so that
+ * the macro() production keeps seeing one continuous content stream, and the closing marker of the macro is not
+ * recognized. Mirrors VERBATIM_CONTEXT, except that it returns to MACRO_CONTEXT instead of the preceding state.
+ */
+<MACRO_VERBATIM_CONTEXT> TOKEN:
+{
+      <MACRO_VERBATIM_START: "{" ("{")? ("{")? > {
+          if (image.length() == 3) {
+              macroVerbatimDepth++;
+          }
+          matchedToken.kind = MACRO_CONTENT;
+      }
+    | <MACRO_VERBATIM_END: "}" ("}")? ("}")? > {
+          if (image.length() == 3) {
+              macroVerbatimDepth--;
+              if (macroVerbatimDepth == 0) {
+                  SwitchTo(MACRO_CONTEXT);
+              }
+          }
+          matchedToken.kind = MACRO_CONTENT;
+      }
+    | <MACRO_VERBATIM_CONTENT: (
+          "~" ~[]
+        | ~["}", "{", "~"]
+      )+ > {
+          matchedToken.kind = MACRO_CONTENT;
+      }
 }
 
 <*> TOKEN:

--- a/xwiki-rendering-wikimodel/src/main/javacc/XWiki21Scanner.jj
+++ b/xwiki-rendering-wikimodel/src/main/javacc/XWiki21Scanner.jj
@@ -208,9 +208,11 @@ TOKEN_MGR_DECLS: {
     int tableDepth = 0; 
     String macroName = "";
     int macroDepth = 0;
+    int macroVerbatimDepth = 0;
     void initMacro(CharSequence buf) {
         macroName = getMacroName(buf);
         macroDepth = 1;
+        macroVerbatimDepth = 0;
     }
     String getMacroName(CharSequence buf) {
         Matcher matcher = MACRO_NAME_PATTERN.matcher(buf);
@@ -409,8 +411,52 @@ TOKEN_MGR_DECLS: {
             }
         }
     }
+    /*
+     * Verbatim content is literal, so the closing marker of the macro must not be recognized inside it. This token is
+     * only a look-ahead checking that the verbatim block is actually closed: all of it but the opening "{{{" is backed
+     * up and rescanned in MACRO_VERBATIM_CONTEXT, which counts the nesting. An unterminated "{{{" doesn't match here
+     * and is scanned character by character as before, so that it cannot swallow the rest of the document.
+     */
+    | <MACRO_VERBATIM_LOOKAHEAD: "{{{" ( "~" ~[] | ~["}", "~"] | "}" ~["}", "~"] | "}}" ~["}", "~"] )* "}}}" > {
+        {
+            input_stream.backup(image.length() - "{{{".length());
+            matchedToken.image = "{{{";
+            matchedToken.kind = MACRO_CONTENT;
+            macroVerbatimDepth = 1;
+        }
+      } : MACRO_VERBATIM_CONTEXT
     | <MACRO_CONTENT: ( <XWIKI_CHAR> | <SPACE> |<NEW_LINE> | <XWIKI_SPECIAL_SYMBOL> ) >
 
+}
+
+/*
+ * Scans the verbatim blocks that appear inside the content of a macro. Everything is reported as MACRO_CONTENT so that
+ * the macro() production keeps seeing one continuous content stream, and the closing marker of the macro is not
+ * recognized. Mirrors VERBATIM_CONTEXT, except that it returns to MACRO_CONTEXT instead of the preceding state.
+ */
+<MACRO_VERBATIM_CONTEXT> TOKEN:
+{
+      <MACRO_VERBATIM_START: "{" ("{")? ("{")? > {
+          if (image.length() == 3) {
+              macroVerbatimDepth++;
+          }
+          matchedToken.kind = MACRO_CONTENT;
+      }
+    | <MACRO_VERBATIM_END: "}" ("}")? ("}")? > {
+          if (image.length() == 3) {
+              macroVerbatimDepth--;
+              if (macroVerbatimDepth == 0) {
+                  SwitchTo(MACRO_CONTEXT);
+              }
+          }
+          matchedToken.kind = MACRO_CONTENT;
+      }
+    | <MACRO_VERBATIM_CONTENT: (
+          "~" ~[]
+        | ~["}", "{", "~"]
+      )+ > {
+          matchedToken.kind = MACRO_CONTENT;
+      }
 }
 
 <*> TOKEN:


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-817

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a new MACRO_VERBATIM_CONTEXT state in the parser that mirrors VERBATIM_CONTEXT so everything inside nested verbatim blocks is treated as macro content.
* Add a MACRO_VERBATIM_LOOKAHEAD guard token to avoid entering the special state when the verbatim is unclosed.
* Track verbatim depth similar to the existing macro depth to track nesting.

New tests, each with both an xwiki/2.0 and an xwiki/2.1 input:
* macro40: the closing marker inside a verbatim block
* macro41: an unterminated "{{{" still closes the macro
* macro42: the marker inside a nested verbatim block, which is what printVerbatimContent produces for verbatim content containing "{{{...}}}"
* macro43: an escaped "~{{/box}}" does not close the macro
* macro44: an edge case regarding the look-ahead which detects closing verbatim even after the macro ends

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I don't know how relevant this fix actually is, it naturally appeared when fixing XRENDERING-815, so I asked Claude Code to fix it. And it can be easily triggered in the WYSIWYG editor. Still, it feels like an edge case.
* The edge case shown in macro44 feels like the most dangerous part of this change.
* We could also decide to postpone this change to a xwiki/2.2 syntax.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Whole xwiki-rendering with quality profile (and legacy and standalone).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, feels way too dangerous.